### PR TITLE
Fixing a crash on suggestions with ls/dir

### DIFF
--- a/src/Microsoft.HttpRepl.Tests/Commands/ListCommandTests.cs
+++ b/src/Microsoft.HttpRepl.Tests/Commands/ListCommandTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.HttpRepl.Commands;
+using Microsoft.HttpRepl.Fakes;
+using Microsoft.HttpRepl.Preferences;
+using Microsoft.Repl.Parsing;
+using Xunit;
+
+namespace Microsoft.HttpRepl.Tests.Commands
+{
+    public class ListCommandTests : CommandTestsBase
+    {
+        [Fact]
+        public void Suggest_WithBlankSecondParameter_NoExceptionAndNullSuggestions()
+        {
+            ArrangeInputs(commandText: "dir ",
+                          baseAddress: "https://localhost/",
+                          path: "/",
+                          urlsWithResponse: null,
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out _,
+                          out IPreferences preferences);
+
+            ListCommand listCommand = new ListCommand(preferences);
+
+            IEnumerable<string> suggestions = listCommand.Suggest(shellState, httpState, parseResult);
+
+            Assert.Empty(suggestions);
+        }
+    }
+}

--- a/src/Microsoft.Repl/Commanding/CommandWithStructuredInputBase.cs
+++ b/src/Microsoft.Repl/Commanding/CommandWithStructuredInputBase.cs
@@ -37,16 +37,22 @@ namespace Microsoft.Repl.Commanding
                 ? string.Empty
                 : parseResult.Sections[parseResult.SelectedSection].Substring(0, parseResult.CaretPositionWithinSelectedSection);
 
-            //If we're completing in a name position, offer completion for the command name
-            if (parseResult.SelectedSection < InputSpec.CommandName.Count)
+
+            // Check the various command name permutations to see if we might be completing one of them
+            IReadOnlyList<string> commandName = null;
+            for (int j = 0; j < InputSpec.CommandName.Count; ++j)
             {
-                IReadOnlyList<string> commandName = null;
-                for (int j = 0; j < InputSpec.CommandName.Count; ++j)
+                IReadOnlyList<string> currentCommandNameParts = InputSpec.CommandName[j];
+                
+                //If we're completing in a name position, offer completion for the command name
+                if (parseResult.SelectedSection < currentCommandNameParts.Count)
                 {
                     bool success = true;
                     for (int i = 0; i < parseResult.SelectedSection; ++i)
                     {
-                        if (!string.Equals(InputSpec.CommandName[j][i], parseResult.Sections[i], StringComparison.OrdinalIgnoreCase))
+                        string currentCommandNamePart = currentCommandNameParts[i];
+                        string currentParseSection = parseResult.Sections[i];
+                        if (!string.Equals(currentCommandNamePart, currentParseSection, StringComparison.OrdinalIgnoreCase))
                         {
                             success = false;
                             break;
@@ -55,20 +61,15 @@ namespace Microsoft.Repl.Commanding
 
                     if (success)
                     {
-                        commandName = InputSpec.CommandName[j];
+                        commandName = currentCommandNameParts;
                         break;
                     }
                 }
+            }
 
-                if (commandName is null)
-                {
-                    return null;
-                }
-
-                if (commandName[parseResult.SelectedSection].StartsWith(normalCompletionString, StringComparison.OrdinalIgnoreCase))
-                {
-                    return new[] {commandName[parseResult.SelectedSection]};
-                }
+            if (commandName?.Count > parseResult.SelectedSection && commandName[parseResult.SelectedSection].StartsWith(normalCompletionString, StringComparison.OrdinalIgnoreCase))
+            {
+                return new[] { commandName[parseResult.SelectedSection] };
             }
 
             if (commandInput is null)


### PR DESCRIPTION
This fixes #135. The actual exception was thrown by the original line 68, but the problem was a little more complex than just fixing that - it shouldn't have even been in that block of code to begin with.