### PR TITLE
Change set swagger command to allow both relative (to the base address) and absolute urls

### DIFF
--- a/src/Microsoft.HttpRepl.Fakes/MockHttpContent.cs
+++ b/src/Microsoft.HttpRepl.Fakes/MockHttpContent.cs
@@ -26,7 +26,7 @@ namespace Microsoft.HttpRepl.Fakes
 
         protected override bool TryComputeLength(out long length)
         {
-            length = Content.Length;
+            length = Content?.Length ?? 0;
             return true;
         }
     }

--- a/src/Microsoft.HttpRepl.Fakes/MockHttpContent.cs
+++ b/src/Microsoft.HttpRepl.Fakes/MockHttpContent.cs
@@ -11,22 +11,22 @@ namespace Microsoft.HttpRepl.Fakes
 {
     public class MockHttpContent : HttpContent
     {
-        public string Content { get; set; }
+        public string Content { get; }
 
         public MockHttpContent(string content)
         {
-            Content = content;
+            Content = content ?? string.Empty;
         }
 
         protected async override Task SerializeToStreamAsync(Stream stream, TransportContext context)
         {
             byte[] byteArray = Encoding.ASCII.GetBytes(Content);
-            await stream.WriteAsync(byteArray, 0, Content.Length);
+            await stream.WriteAsync(byteArray, 0, byteArray.Length);
         }
 
         protected override bool TryComputeLength(out long length)
         {
-            length = Content?.Length ?? 0;
+            length = Content.Length;
             return true;
         }
     }

--- a/src/Microsoft.HttpRepl.Tests/Commands/SetSwaggerCommandTests.cs
+++ b/src/Microsoft.HttpRepl.Tests/Commands/SetSwaggerCommandTests.cs
@@ -377,12 +377,72 @@ namespace Microsoft.HttpRepl.Tests.Commands
             Assert.Equal("Values", childDirectoryNames.First());
         }
 
-        private async Task<IDirectoryStructure> GetDirectoryStructure(string response, string parseResultSections, string baseAddress)
+        [Fact]
+        public async Task ExecuteAsync_WithAbsoluteUrl_SetsApiDefinition()
+        {
+            string response = @"{
+  ""swagger"": ""2.0"",
+  ""paths"": {
+    ""/api/Values"": {
+      ""post"": {
+        
+      }
+    }
+  }
+}";
+
+            string swaggerAddress = "http://localhost/swagger.json";
+            string baseAddress = "https://petstore.swagger.io/v2/";
+            string requestAddress = swaggerAddress;
+            string parseResultSections = "set swagger " + swaggerAddress;
+            IDirectoryStructure directoryStructure = await GetDirectoryStructure(response, parseResultSections, requestAddress, baseAddress).ConfigureAwait(false);
+
+            Assert.NotNull(directoryStructure);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithRelativeUrlAndBaseAddress_SetsApiDefinition()
+        {
+            string response = @"{
+  ""swagger"": ""2.0"",
+  ""paths"": {
+    ""/api/Values"": {
+      ""post"": {
+        
+      }
+    }
+  }
+}";
+
+            string swaggerAddress = "/swagger.json";
+            string baseAddress = "http://localhost/";
+            string requestAddress = "http://localhost/swagger.json";
+            string parseResultSections = "set swagger " + swaggerAddress;
+            IDirectoryStructure directoryStructure = await GetDirectoryStructure(response, parseResultSections, requestAddress, baseAddress).ConfigureAwait(false);
+
+            Assert.NotNull(directoryStructure);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithRelativeUrlAndNoBaseAddress_DoesNotSetApiDefinition()
+        {
+            string swaggerAddress = "/swagger.json";
+            string baseAddress = null;
+            string parseResultSections = "set swagger " + swaggerAddress;
+            IDirectoryStructure directoryStructure = await GetDirectoryStructure(null, parseResultSections, null, baseAddress).ConfigureAwait(false);
+
+            Assert.Null(directoryStructure);
+        }
+
+        private async Task<IDirectoryStructure> GetDirectoryStructure(string response, string parseResultSections, string requestAddress, string baseAddress = null)
         {
             MockedShellState shellState = new MockedShellState();
             IDictionary<string, string> urlsWithResponse = new Dictionary<string, string>();
-            urlsWithResponse.Add(baseAddress, response);
-            HttpState httpState = GetHttpState(out _, out _, urlsWithResponse: urlsWithResponse);
+            if (!(requestAddress is null))
+            {
+                urlsWithResponse.Add(requestAddress, response);
+            }
+            HttpState httpState = GetHttpState(out _, out _, baseAddress: baseAddress, urlsWithResponse: urlsWithResponse);
             ICoreParseResult parseResult = CoreParseResultHelper.Create(parseResultSections);
             SetSwaggerCommand setSwaggerCommand = new SetSwaggerCommand();
 

--- a/src/Microsoft.HttpRepl.Tests/Commands/SetSwaggerCommandTests.cs
+++ b/src/Microsoft.HttpRepl.Tests/Commands/SetSwaggerCommandTests.cs
@@ -392,7 +392,7 @@ namespace Microsoft.HttpRepl.Tests.Commands
 }";
 
             string swaggerAddress = "http://localhost/swagger.json";
-            string baseAddress = "https://petstore.swagger.io/v2/";
+            string baseAddress = "https://localhost/v2/";
             string requestAddress = swaggerAddress;
             string parseResultSections = "set swagger " + swaggerAddress;
             IDirectoryStructure directoryStructure = await GetDirectoryStructure(response, parseResultSections, requestAddress, baseAddress).ConfigureAwait(false);

--- a/src/Microsoft.HttpRepl/Commands/SetSwaggerCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/SetSwaggerCommand.cs
@@ -246,13 +246,22 @@ namespace Microsoft.HttpRepl.Commands
                 return;
             }
 
-            if (parseResult.Sections.Count != 3 || string.IsNullOrEmpty(parseResult.Sections[2]) || !Uri.TryCreate(parseResult.Sections[2], UriKind.Absolute, out Uri serverUri))
+            if (parseResult.Sections.Count != 3 || string.IsNullOrEmpty(parseResult.Sections[2]))
             {
                 shellState.ConsoleManager.Error.WriteLine(Strings.SetSwaggerCommand_SpecifySwaggerDocument.SetColor(programState.ErrorColor));
             }
             else
             {
-                await CreateDirectoryStructureForSwaggerEndpointAsync(shellState, programState, serverUri, cancellationToken).ConfigureAwait(false);
+                Uri serverUri;
+                if ((Uri.IsWellFormedUriString(parseResult.Sections[2], UriKind.Absolute) && Uri.TryCreate(parseResult.Sections[2], UriKind.Absolute, out serverUri)) ||
+                    (!(programState.BaseAddress is null) && Uri.TryCreate(programState.BaseAddress, parseResult.Sections[2], out serverUri)))
+                {
+                    await CreateDirectoryStructureForSwaggerEndpointAsync(shellState, programState, serverUri, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    shellState.ConsoleManager.Error.WriteLine(Strings.SetSwaggerCommand_InvalidSwaggerUri.SetColor(programState.ErrorColor));
+                }
             }
         }
 

--- a/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
+++ b/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
@@ -399,6 +399,15 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Must specify a valid swagger document.
+        /// </summary>
+        internal static string SetSwaggerCommand_InvalidSwaggerUri {
+            get {
+                return ResourceManager.GetString("SetSwaggerCommand_InvalidSwaggerUri", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Must specify a swagger document.
         /// </summary>
         internal static string SetSwaggerCommand_SpecifySwaggerDocument {

--- a/src/Microsoft.HttpRepl/Resources/Strings.resx
+++ b/src/Microsoft.HttpRepl/Resources/Strings.resx
@@ -264,4 +264,7 @@ When +history option is specified, commands specified in the text file will be a
     <value>If {0} is not an absolute URI, {1} must be specified.</value>
     <comment>{0} is the name of the commandSpecifiedPath parameter, {1} is the name of the baseAddress uri parameter</comment>
   </data>
+  <data name="SetSwaggerCommand_InvalidSwaggerUri" xml:space="preserve">
+    <value>Must specify a valid swagger document</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes #136 by allowing the user to specify either an absolute url (which already worked) or a relative url (relative to the set base address). If no base address is set, only absolute will work, for obvious reasons. 