### PR TITLE
Adds warnings for ls/dir commands when there's no base/swagger/structure, so nothing to do.

### DIFF
--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/ListCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/ListCommandTests.cs
@@ -85,12 +85,12 @@ ls";
             string expected = NormalizeOutput(@"(Disconnected)~ set base [BaseUrl]
 
 [BaseUrl]/~ ls
-No directory structure has been set, so there is nothing to list.
+No directory structure has been set, so there is nothing to list. Use the ""set swagger"" command to set a directory structure based on a swagger definition.
 
 [BaseUrl]/~ cd api
 
 [BaseUrl]/api~ ls
-No directory structure has been set, so there is nothing to list.
+No directory structure has been set, so there is nothing to list. Use the ""set swagger"" command to set a directory structure based on a swagger definition.
 
 [BaseUrl]/api~", null);
 
@@ -110,7 +110,7 @@ ls";
 [BaseUrl]/~ cd api/Values
 
 [BaseUrl]/api/Values~ ls
-No directory structure has been set, so there is nothing to list.
+No directory structure has been set, so there is nothing to list. Use the ""set swagger"" command to set a directory structure based on a swagger definition.
 
 [BaseUrl]/api/Values~", null);
 

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/ListCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/ListCommandTests.cs
@@ -85,10 +85,12 @@ ls";
             string expected = NormalizeOutput(@"(Disconnected)~ set base [BaseUrl]
 
 [BaseUrl]/~ ls
+No directory structure has been set, so there is nothing to list.
 
 [BaseUrl]/~ cd api
 
 [BaseUrl]/api~ ls
+No directory structure has been set, so there is nothing to list.
 
 [BaseUrl]/api~", null);
 
@@ -108,6 +110,7 @@ ls";
 [BaseUrl]/~ cd api/Values
 
 [BaseUrl]/api/Values~ ls
+No directory structure has been set, so there is nothing to list.
 
 [BaseUrl]/api/Values~", null);
 

--- a/src/Microsoft.HttpRepl.Tests/Commands/ListCommandTests.cs
+++ b/src/Microsoft.HttpRepl.Tests/Commands/ListCommandTests.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.HttpRepl.Commands;
 using Microsoft.HttpRepl.Fakes;
 using Microsoft.HttpRepl.Preferences;
-using Microsoft.Repl.ConsoleHandling;
 using Microsoft.Repl.Parsing;
 using Xunit;
 

--- a/src/Microsoft.HttpRepl.Tests/Commands/ListCommandTests.cs
+++ b/src/Microsoft.HttpRepl.Tests/Commands/ListCommandTests.cs
@@ -1,10 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.HttpRepl.Commands;
 using Microsoft.HttpRepl.Fakes;
 using Microsoft.HttpRepl.Preferences;
+using Microsoft.Repl.ConsoleHandling;
 using Microsoft.Repl.Parsing;
 using Xunit;
 
@@ -12,6 +16,81 @@ namespace Microsoft.HttpRepl.Tests.Commands
 {
     public class ListCommandTests : CommandTestsBase
     {
+        [Fact]
+        public async Task ExecuteAsync_NoBaseAddress_ShowsWarning()
+        {
+            ArrangeInputs(commandText: "ls",
+                          baseAddress: "http://lcoalhost/",
+                          path: "/",
+                          urlsWithResponse: null,
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out _,
+                          out IPreferences preferences);
+
+            httpState.BaseAddress = null;
+            httpState.SwaggerEndpoint = new Uri("http://localhost/swagger.json");
+            httpState.Structure = new DirectoryStructure(null);
+
+            ListCommand listCommand = new ListCommand(preferences);
+
+            await listCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
+
+            Assert.Single(shellState.Output);
+            Assert.Equal(Resources.Strings.ListCommand_Error_NoBaseAddress, shellState.Output[0]);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_NoSwagger_ShowsWarning()
+        {
+            ArrangeInputs(commandText: "ls",
+                          baseAddress: "http://localhost/",
+                          path: "/",
+                          urlsWithResponse: null,
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out _,
+                          out IPreferences preferences);
+
+            httpState.BaseAddress = new Uri("http://localhost/swagger.json");
+            httpState.SwaggerEndpoint = null;
+            httpState.Structure = new DirectoryStructure(null);
+
+            ListCommand listCommand = new ListCommand(preferences);
+
+            await listCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
+
+            Assert.Single(shellState.Output);
+            Assert.Equal(Resources.Strings.ListCommand_Error_NoDirectoryStructure, shellState.Output[0]);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_NoStructure_ShowsWarning()
+        {
+            ArrangeInputs(commandText: "ls",
+                          baseAddress: "http://localhost/",
+                          path: "/",
+                          urlsWithResponse: null,
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out _,
+                          out IPreferences preferences);
+
+            httpState.BaseAddress = new Uri("http://localhost/swagger.json");
+            httpState.SwaggerEndpoint = new Uri("http://localhost/swagger.json");
+            httpState.Structure = null;
+
+            ListCommand listCommand = new ListCommand(preferences);
+
+            await listCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
+
+            Assert.Single(shellState.Output);
+            Assert.Equal(Resources.Strings.ListCommand_Error_NoDirectoryStructure, shellState.Output[0]);
+        }
+
         [Fact]
         public void Suggest_WithBlankSecondParameter_NoExceptionAndNullSuggestions()
         {

--- a/src/Microsoft.HttpRepl/Commands/ListCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ListCommand.cs
@@ -40,8 +40,15 @@ namespace Microsoft.HttpRepl.Commands
                 }
             }
 
-            if (programState.Structure == null || programState.BaseAddress == null)
+            if (programState.BaseAddress is null)
             {
+                shellState.ConsoleManager.WriteLine(Resources.Strings.ListCommand_Error_NoBaseAddress.SetColor(programState.WarningColor));
+                return;
+            }
+
+            if (programState.SwaggerEndpoint is null || programState.Structure is null)
+            {
+                shellState.ConsoleManager.WriteLine(Resources.Strings.ListCommand_Error_NoDirectoryStructure.SetColor(programState.WarningColor));
                 return;
             }
 

--- a/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
+++ b/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
@@ -187,7 +187,7 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No base address has been set, so there is nothing to list..
+        ///   Looks up a localized string similar to No base address has been set, so there is nothing to list. Use the &quot;set base&quot; command to set a base address..
         /// </summary>
         internal static string ListCommand_Error_NoBaseAddress {
             get {
@@ -196,7 +196,7 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No directory structure has been set, so there is nothing to list..
+        ///   Looks up a localized string similar to No directory structure has been set, so there is nothing to list. Use the &quot;set swagger&quot; command to set a directory structure based on a swagger definition..
         /// </summary>
         internal static string ListCommand_Error_NoDirectoryStructure {
             get {

--- a/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
+++ b/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
@@ -187,6 +187,24 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No base address has been set, so there is nothing to list..
+        /// </summary>
+        internal static string ListCommand_Error_NoBaseAddress {
+            get {
+                return ResourceManager.GetString("ListCommand_Error_NoBaseAddress", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No directory structure has been set, so there is nothing to list..
+        /// </summary>
+        internal static string ListCommand_Error_NoDirectoryStructure {
+            get {
+                return ResourceManager.GetString("ListCommand_Error_NoDirectoryStructure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Show all endpoints for the current path.
         /// </summary>
         internal static string ListCommand_HelpSummary {

--- a/src/Microsoft.HttpRepl/Resources/Strings.resx
+++ b/src/Microsoft.HttpRepl/Resources/Strings.resx
@@ -265,10 +265,10 @@ When +history option is specified, commands specified in the text file will be a
     <comment>{0} is the name of the commandSpecifiedPath parameter, {1} is the name of the baseAddress uri parameter</comment>
   </data>
   <data name="ListCommand_Error_NoBaseAddress" xml:space="preserve">
-    <value>No base address has been set, so there is nothing to list.</value>
+    <value>No base address has been set, so there is nothing to list. Use the "set base" command to set a base address.</value>
   </data>
   <data name="ListCommand_Error_NoDirectoryStructure" xml:space="preserve">
-    <value>No directory structure has been set, so there is nothing to list.</value>
+    <value>No directory structure has been set, so there is nothing to list. Use the "set swagger" command to set a directory structure based on a swagger definition.</value>
   </data>
   <data name="SetSwaggerCommand_InvalidSwaggerUri" xml:space="preserve">
     <value>Must specify a valid swagger document</value>

--- a/src/Microsoft.HttpRepl/Resources/Strings.resx
+++ b/src/Microsoft.HttpRepl/Resources/Strings.resx
@@ -264,6 +264,12 @@ When +history option is specified, commands specified in the text file will be a
     <value>If {0} is not an absolute URI, {1} must be specified.</value>
     <comment>{0} is the name of the commandSpecifiedPath parameter, {1} is the name of the baseAddress uri parameter</comment>
   </data>
+  <data name="ListCommand_Error_NoBaseAddress" xml:space="preserve">
+    <value>No base address has been set, so there is nothing to list.</value>
+  </data>
+  <data name="ListCommand_Error_NoDirectoryStructure" xml:space="preserve">
+    <value>No directory structure has been set, so there is nothing to list.</value>
+  </data>
   <data name="SetSwaggerCommand_InvalidSwaggerUri" xml:space="preserve">
     <value>Must specify a valid swagger document</value>
   </data>


### PR DESCRIPTION
Resolves #152 