### PR TITLE
Fix BaseHttpCommand to only print the request body once if echo is on

### DIFF
--- a/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
@@ -380,11 +380,6 @@ namespace Microsoft.HttpRepl.Commands
             consoleManager.WriteLine();
             consoleManager.WriteLine($"Response from {hostString}...".SetColor(requestConfig.AddressColor));
             consoleManager.WriteLine();
-
-            foreach (string responseLine in responseOutput)
-            {
-                consoleManager.WriteLine(responseLine);
-            }
         }
 
         private static async Task FormatBodyAsync(DefaultCommandInput<ICoreParseResult> commandInput, HttpState programState, IConsoleManager consoleManager, HttpContent content, List<string> bodyFileOutput, IPreferences preferences, CancellationToken cancellationToken)

--- a/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
@@ -267,7 +267,14 @@ namespace Microsoft.HttpRepl.Commands
 
             if (echoRequest)
             {
-                await HandleEchoRequest(commandInput, consoleManager, programState, response, cancellationToken);
+                RequestConfig requestConfig = new RequestConfig(_preferences);
+                string hostString = response.RequestMessage.RequestUri.Scheme + "://" + response.RequestMessage.RequestUri.Host + (!response.RequestMessage.RequestUri.IsDefaultPort ? ":" + response.RequestMessage.RequestUri.Port : "");
+                await HandleEchoRequest(commandInput, consoleManager, programState, response, requestConfig, hostString, cancellationToken);
+
+                // Only need to write out this separator if we've echoed the request
+                consoleManager.WriteLine();
+                consoleManager.WriteLine($"Response from {hostString}...".SetColor(requestConfig.AddressColor));
+                consoleManager.WriteLine();
             }
 
             ResponseConfig responseConfig = new ResponseConfig(_preferences);
@@ -339,12 +346,10 @@ namespace Microsoft.HttpRepl.Commands
             IConsoleManager consoleManager,
             HttpState programState,
             HttpResponseMessage response,
+            RequestConfig requestConfig,
+            string hostString,
             CancellationToken cancellationToken)
         {
-            RequestConfig requestConfig = new RequestConfig(_preferences);
-            ResponseConfig responseConfig = new ResponseConfig(_preferences);
-
-            string hostString = response.RequestMessage.RequestUri.Scheme + "://" + response.RequestMessage.RequestUri.Host + (!response.RequestMessage.RequestUri.IsDefaultPort ? ":" + response.RequestMessage.RequestUri.Port : "");
             consoleManager.WriteLine($"Request to {hostString}...".SetColor(requestConfig.AddressColor));
             consoleManager.WriteLine();
 
@@ -376,10 +381,6 @@ namespace Microsoft.HttpRepl.Commands
             {
                 await FormatBodyAsync(commandInput, programState, consoleManager, response.RequestMessage.Content, responseOutput, _preferences, cancellationToken).ConfigureAwait(false);
             }
-
-            consoleManager.WriteLine();
-            consoleManager.WriteLine($"Response from {hostString}...".SetColor(requestConfig.AddressColor));
-            consoleManager.WriteLine();
         }
 
         private static async Task FormatBodyAsync(DefaultCommandInput<ICoreParseResult> commandInput, HttpState programState, IConsoleManager consoleManager, HttpContent content, List<string> bodyFileOutput, IPreferences preferences, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes #196.

For some reason, there was an extra loop outputting the request body after the response marker. This removes that.