### PR TITLE
Fix OpenApiV3ApiDefinitionReader to detect request body schema

### DIFF
--- a/src/Microsoft.HttpRepl/OpenApi/OpenApiV3ApiDefinitionReader.cs
+++ b/src/Microsoft.HttpRepl/OpenApi/OpenApiV3ApiDefinitionReader.cs
@@ -98,11 +98,11 @@ namespace Microsoft.HttpRepl.OpenApi
                                 foreach (JProperty contentTypeEntry in contentTypeLookup.Properties())
                                 {
                                     List<Parameter> parametersByContentType = new List<Parameter>(parameters);
-                                    Parameter p = bodyObject.ToObject<Parameter>();
+                                    Parameter p = new Parameter();
                                     p.Location = "body";
                                     p.IsRequired = bodyObject["required"]?.ToObject<bool>() ?? false;
 
-                                    if (!(bodyObject["schema"] is JObject schemaObject))
+                                    if (!(contentTypeEntry.Value is JObject contentTypeObject) || !(contentTypeObject["schema"] is JObject schemaObject))
                                     {
                                         schemaObject = null;
                                     }


### PR DESCRIPTION
Fixes #199 so that the V3 API reader understands and records the schema used in a request body.