### PR TITLE
Change the prompt ending to be a > rather than a ~

### DIFF
--- a/src/Microsoft.HttpRepl.IntegrationTests/BaseIntegrationTest.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/BaseIntegrationTest.cs
@@ -34,8 +34,8 @@ namespace Microsoft.HttpRepl.IntegrationTests
         {
             // The console implementation uses trailing whitespace when a new line's text is shorter than the previous
             // line.  For example (the trailing * represent spaces):
-            // Line 1: (Disconnected)~ run C:\path\to\a\test\script\file.txt
-            // Line 2: (Disconnected)~ set base http://localhost:12345******
+            // Line 1: (Disconnected)> run C:\path\to\a\test\script\file.txt
+            // Line 2: (Disconnected)> set base http://localhost:12345******
             // This having this whitespace makes it harder to read/write test baselines, so here we'll trim each line
             string result = string.Join(Environment.NewLine, output.Split(Environment.NewLine).Select(l => l.TrimEnd()));
 

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/EchoCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/EchoCommandTests.cs
@@ -24,12 +24,12 @@ echo on";
 
             string output = await RunTestScript(scriptText, _serverConfig.BaseAddress);
 
-            string expected = NormalizeOutput(@"(Disconnected)~ set base [BaseUrl]
+            string expected = NormalizeOutput(@"(Disconnected)> set base [BaseUrl]
 
-[BaseUrl]/~ echo on
+[BaseUrl]/> echo on
 Request echoing is on
 
-[BaseUrl]/~", null);
+[BaseUrl]/>", null);
 
             Assert.Equal(expected, output);
         }
@@ -42,12 +42,12 @@ echo off";
 
             string output = await RunTestScript(scriptText, _serverConfig.BaseAddress);
 
-            string expected = NormalizeOutput(@"(Disconnected)~ set base [BaseUrl]
+            string expected = NormalizeOutput(@"(Disconnected)> set base [BaseUrl]
 
-[BaseUrl]/~ echo off
+[BaseUrl]/> echo off
 Request echoing is off
 
-[BaseUrl]/~", null);
+[BaseUrl]/>", null);
 
             Assert.Equal(expected, output);
         }

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/GetCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/GetCommandTests.cs
@@ -25,14 +25,14 @@ get";
 
             string output = await RunTestScript(scriptText, _serverConfig.BaseAddress);
 
-            string expected = NormalizeOutput(@"(Disconnected)~ connect [BaseUrl]
+            string expected = NormalizeOutput(@"(Disconnected)> connect [BaseUrl]
 Using a base address of [BaseUrl]/
 Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
 
-[BaseUrl]/~ cd api/values
+[BaseUrl]/> cd api/values
 /api/values    [get|post]
 
-[BaseUrl]/api/values~ get
+[BaseUrl]/api/values> get
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Date: [Date]
@@ -45,7 +45,7 @@ Transfer-Encoding: chunked
 ]
 
 
-[BaseUrl]/api/values~", null);
+[BaseUrl]/api/values>", null);
 
             Assert.Equal(expected, output);
         }
@@ -59,14 +59,14 @@ get 5";
 
             string output = await RunTestScript(scriptText, _serverConfig.BaseAddress);
 
-            string expected = NormalizeOutput(@"(Disconnected)~ connect [BaseUrl]
+            string expected = NormalizeOutput(@"(Disconnected)> connect [BaseUrl]
 Using a base address of [BaseUrl]/
 Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
 
-[BaseUrl]/~ cd api/values
+[BaseUrl]/> cd api/values
 /api/values    [get|post]
 
-[BaseUrl]/api/values~ get 5
+[BaseUrl]/api/values> get 5
 HTTP/1.1 200 OK
 Content-Type: text/plain; charset=utf-8
 Date: [Date]
@@ -76,7 +76,7 @@ Transfer-Encoding: chunked
 value
 
 
-[BaseUrl]/api/values~", null);
+[BaseUrl]/api/values>", null);
 
             Assert.Equal(expected, output);
         }
@@ -90,15 +90,15 @@ get";
 
             string output = await RunTestScript(scriptText, _serverConfig.BaseAddress);
 
-            string expected = NormalizeOutput(@"(Disconnected)~ connect [BaseUrl]
+            string expected = NormalizeOutput(@"(Disconnected)> connect [BaseUrl]
 Using a base address of [BaseUrl]/
 Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
 
-[BaseUrl]/~ cd api/invalidpath
+[BaseUrl]/> cd api/invalidpath
 Warning: The '/api/invalidpath' endpoint is not present in the Swagger metadata
 /api/invalidpath    []
 
-[BaseUrl]/api/invalidpath~ get
+[BaseUrl]/api/invalidpath> get
 HTTP/1.1 404 Not Found
 Content-Length: 0
 Date: [Date]
@@ -107,7 +107,7 @@ Server: Kestrel
 
 
 
-[BaseUrl]/api/invalidpath~", null);
+[BaseUrl]/api/invalidpath>", null);
 
             Assert.Equal(expected, output);
         }
@@ -119,7 +119,7 @@ Server: Kestrel
 
             string output = await RunTestScript(scriptText, _serverConfig.BaseAddress);
 
-            string expected = NormalizeOutput(@"(Disconnected)~ get [BaseUrl]/api/values
+            string expected = NormalizeOutput(@"(Disconnected)> get [BaseUrl]/api/values
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Date: [Date]
@@ -132,7 +132,7 @@ Transfer-Encoding: chunked
 ]
 
 
-(Disconnected)~", null);
+(Disconnected)>", null);
 
             Assert.Equal(expected, output);
         }

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/ListCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/ListCommandTests.cs
@@ -28,23 +28,23 @@ ls";
             string output = await RunTestScript(scriptText, _swaggerServerConfig.BaseAddress);
 
             // make sure to normalize newlines in the expected output
-            string expected = NormalizeOutput(@"(Disconnected)~ connect [BaseUrl]
+            string expected = NormalizeOutput(@"(Disconnected)> connect [BaseUrl]
 Using a base address of [BaseUrl]/
 Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
 
-[BaseUrl]/~ ls
+[BaseUrl]/> ls
 .     []
 api   []
 
-[BaseUrl]/~ cd api
+[BaseUrl]/> cd api
 /api    []
 
-[BaseUrl]/api~ ls
+[BaseUrl]/api> ls
 .        []
 ..       []
 Values   [get|post]
 
-[BaseUrl]/api~", null);
+[BaseUrl]/api>", null);
 
             Assert.Equal(expected, output);
         }
@@ -57,19 +57,19 @@ cd api/Values
 ls";
             string output = await RunTestScript(scriptText, _swaggerServerConfig.BaseAddress);
 
-            string expected = NormalizeOutput(@"(Disconnected)~ connect [BaseUrl]
+            string expected = NormalizeOutput(@"(Disconnected)> connect [BaseUrl]
 Using a base address of [BaseUrl]/
 Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
 
-[BaseUrl]/~ cd api/Values
+[BaseUrl]/> cd api/Values
 /api/Values    [get|post]
 
-[BaseUrl]/api/Values~ ls
+[BaseUrl]/api/Values> ls
 .      [get|post]
 ..     []
 {id}   [get|put|delete]
 
-[BaseUrl]/api/Values~", null);
+[BaseUrl]/api/Values>", null);
 
             Assert.Equal(expected, output);
         }
@@ -84,17 +84,17 @@ ls";
             string output = await RunTestScript(scriptText, _nonSwaggerServerConfig.BaseAddress);
 
             // make sure to normalize newlines in the expected output
-            string expected = NormalizeOutput(@"(Disconnected)~ set base [BaseUrl]
+            string expected = NormalizeOutput(@"(Disconnected)> set base [BaseUrl]
 
-[BaseUrl]/~ ls
+[BaseUrl]/> ls
 No directory structure has been set, so there is nothing to list. Use the ""set swagger"" command to set a directory structure based on a swagger definition.
 
-[BaseUrl]/~ cd api
+[BaseUrl]/> cd api
 
-[BaseUrl]/api~ ls
+[BaseUrl]/api> ls
 No directory structure has been set, so there is nothing to list. Use the ""set swagger"" command to set a directory structure based on a swagger definition.
 
-[BaseUrl]/api~", null);
+[BaseUrl]/api>", null);
 
             Assert.Equal(expected, output);
         }
@@ -107,14 +107,14 @@ cd api/Values
 ls";
             string output = await RunTestScript(scriptText, _nonSwaggerServerConfig.BaseAddress);
 
-            string expected = NormalizeOutput(@"(Disconnected)~ set base [BaseUrl]
+            string expected = NormalizeOutput(@"(Disconnected)> set base [BaseUrl]
 
-[BaseUrl]/~ cd api/Values
+[BaseUrl]/> cd api/Values
 
-[BaseUrl]/api/Values~ ls
+[BaseUrl]/api/Values> ls
 No directory structure has been set, so there is nothing to list. Use the ""set swagger"" command to set a directory structure based on a swagger definition.
 
-[BaseUrl]/api/Values~", null);
+[BaseUrl]/api/Values>", null);
 
             Assert.Equal(expected, output);
         }

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/SetBaseCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/SetBaseCommandTests.cs
@@ -28,9 +28,9 @@ namespace Microsoft.HttpRepl.IntegrationTests.Commands
 
             string output = await RunTestScript(scriptText, _swaggerServerConfig.BaseAddress);
 
-            string expected = NormalizeOutput(@"(Disconnected)~ set base [BaseUrl]
+            string expected = NormalizeOutput(@"(Disconnected)> set base [BaseUrl]
 
-[BaseUrl]/~", null);
+[BaseUrl]/>", null);
 
             Assert.Equal(expected, output);
         }
@@ -42,9 +42,9 @@ namespace Microsoft.HttpRepl.IntegrationTests.Commands
 
             string output = await RunTestScript(scriptText, _nonSwaggerServerConfig.BaseAddress);
 
-            string expected = NormalizeOutput(@"(Disconnected)~ set base [BaseUrl]
+            string expected = NormalizeOutput(@"(Disconnected)> set base [BaseUrl]
 
-[BaseUrl]/~", null);
+[BaseUrl]/>", null);
 
             Assert.Equal(expected, output);
         }

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/SetHeaderCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/SetHeaderCommandTests.cs
@@ -27,19 +27,19 @@ get";
 
             string output = await RunTestScript(scriptText, _serverConfig.BaseAddress);
 
-            string expected = NormalizeOutput(@"(Disconnected)~ connect [BaseUrl]
+            string expected = NormalizeOutput(@"(Disconnected)> connect [BaseUrl]
 Using a base address of [BaseUrl]/
 Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
 
-[BaseUrl]/~ cd api/values
+[BaseUrl]/> cd api/values
 /api/values    [get|post]
 
-[BaseUrl]/api/values~ echo on
+[BaseUrl]/api/values> echo on
 Request echoing is on
 
-[BaseUrl]/api/values~ set header Accept application/json
+[BaseUrl]/api/values> set header Accept application/json
 
-[BaseUrl]/api/values~ get
+[BaseUrl]/api/values> get
 Request to [BaseUrl]...
 
 GET /api/values HTTP/1.1
@@ -61,7 +61,7 @@ Transfer-Encoding: chunked
 ]
 
 
-[BaseUrl]/api/values~", null);
+[BaseUrl]/api/values>", null);
 
             Assert.Equal(expected, output);
         }
@@ -77,19 +77,19 @@ get";
 
             string output = await RunTestScript(scriptText, _serverConfig.BaseAddress);
 
-            string expected = NormalizeOutput(@"(Disconnected)~ connect [BaseUrl]
+            string expected = NormalizeOutput(@"(Disconnected)> connect [BaseUrl]
 Using a base address of [BaseUrl]/
 Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
 
-[BaseUrl]/~ cd api/values
+[BaseUrl]/> cd api/values
 /api/values    [get|post]
 
-[BaseUrl]/api/values~ echo on
+[BaseUrl]/api/values> echo on
 Request echoing is on
 
-[BaseUrl]/api/values~ set header User-Agent
+[BaseUrl]/api/values> set header User-Agent
 
-[BaseUrl]/api/values~ get
+[BaseUrl]/api/values> get
 Request to [BaseUrl]...
 
 GET /api/values HTTP/1.1
@@ -109,7 +109,7 @@ Transfer-Encoding: chunked
 ]
 
 
-[BaseUrl]/api/values~", null);
+[BaseUrl]/api/values>", null);
 
             Assert.Equal(expected, output);
         }

--- a/src/Microsoft.HttpRepl/HttpState.cs
+++ b/src/Microsoft.HttpRepl/HttpState.cs
@@ -53,7 +53,7 @@ namespace Microsoft.HttpRepl
 
         public string GetPrompt()
         {
-            return $"{GetEffectivePathForPrompt()?.ToString() ?? "(Disconnected)"}~ ";
+            return $"{GetEffectivePathForPrompt()?.ToString() ?? "(Disconnected)"}> ";
         }
 
         public IEnumerable<string> GetApplicableContentTypes(string method, string path)


### PR DESCRIPTION
Resolves #195.

Currently, we use the `~` character at the end of the prompt. However:
1. The `~` character is used on some platforms to indicate the home directory
2. The `>` character is more commonly used as the end of a prompt in other shells

So this changes our usage from `~` to `>`