### PR TITLE
For cd and dir/ls commands, display http verbs in uppercase

### DIFF
--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/ChangeDirectoryCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/ChangeDirectoryCommandTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.HttpRepl.IntegrationTests.SampleApi;
+using Xunit;
+
+namespace Microsoft.HttpRepl.IntegrationTests.Commands
+{
+    public class ChangeDirectoryCommandTests : BaseIntegrationTest, IClassFixture<HttpCommandsFixture<SampleApiServerConfig>>
+    {
+        private readonly SampleApiServerConfig _serverConfig;
+
+        public ChangeDirectoryCommandTests(HttpCommandsFixture<SampleApiServerConfig> fixture)
+        {
+            _serverConfig = fixture.Config;
+        }
+
+        [Fact]
+        public async Task WithSwagger_MethodsAreUppercase()
+        {
+            string scriptText = $@"connect {_serverConfig.BaseAddress}
+ls
+cd api
+ls
+cd Values";
+            string output = await RunTestScript(scriptText, _serverConfig.BaseAddress);
+
+            // make sure to normalize newlines in the expected output
+            string expected = NormalizeOutput(@"(Disconnected)~ connect [BaseUrl]
+Using a base address of [BaseUrl]/
+Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
+
+[BaseUrl]/~ ls
+.     []
+api   []
+
+[BaseUrl]/~ cd api
+/api    []
+
+[BaseUrl]/api~ ls
+.        []
+..       []
+Values   [GET|POST]
+
+[BaseUrl]/api~ cd Values
+/api/Values    [GET|POST]
+
+[BaseUrl]/api/Values~", null);
+
+            Assert.Equal(expected, output);
+        }
+    }
+}

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/ChangeDirectoryCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/ChangeDirectoryCommandTests.cs
@@ -27,26 +27,26 @@ cd Values";
             string output = await RunTestScript(scriptText, _serverConfig.BaseAddress);
 
             // make sure to normalize newlines in the expected output
-            string expected = NormalizeOutput(@"(Disconnected)~ connect [BaseUrl]
+            string expected = NormalizeOutput(@"(Disconnected)> connect [BaseUrl]
 Using a base address of [BaseUrl]/
 Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
 
-[BaseUrl]/~ ls
+[BaseUrl]/> ls
 .     []
 api   []
 
-[BaseUrl]/~ cd api
+[BaseUrl]/> cd api
 /api    []
 
-[BaseUrl]/api~ ls
+[BaseUrl]/api> ls
 .        []
 ..       []
 Values   [GET|POST]
 
-[BaseUrl]/api~ cd Values
+[BaseUrl]/api> cd Values
 /api/Values    [GET|POST]
 
-[BaseUrl]/api/Values~", null);
+[BaseUrl]/api/Values>", null);
 
             Assert.Equal(expected, output);
         }

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/GetCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/GetCommandTests.cs
@@ -30,7 +30,7 @@ Using a base address of [BaseUrl]/
 Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
 
 [BaseUrl]/> cd api/values
-/api/values    [get|post]
+/api/values    [GET|POST]
 
 [BaseUrl]/api/values> get
 HTTP/1.1 200 OK
@@ -64,7 +64,7 @@ Using a base address of [BaseUrl]/
 Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
 
 [BaseUrl]/> cd api/values
-/api/values    [get|post]
+/api/values    [GET|POST]
 
 [BaseUrl]/api/values> get 5
 HTTP/1.1 200 OK

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/ListCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/ListCommandTests.cs
@@ -42,7 +42,7 @@ api   []
 [BaseUrl]/api> ls
 .        []
 ..       []
-Values   [get|post]
+Values   [GET|POST]
 
 [BaseUrl]/api>", null);
 
@@ -62,12 +62,12 @@ Using a base address of [BaseUrl]/
 Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
 
 [BaseUrl]/> cd api/Values
-/api/Values    [get|post]
+/api/Values    [GET|POST]
 
 [BaseUrl]/api/Values> ls
-.      [get|post]
+.      [GET|POST]
 ..     []
-{id}   [get|put|delete]
+{id}   [GET|PUT|DELETE]
 
 [BaseUrl]/api/Values>", null);
 

--- a/src/Microsoft.HttpRepl.IntegrationTests/Commands/SetHeaderCommandTests.cs
+++ b/src/Microsoft.HttpRepl.IntegrationTests/Commands/SetHeaderCommandTests.cs
@@ -32,7 +32,7 @@ Using a base address of [BaseUrl]/
 Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
 
 [BaseUrl]/> cd api/values
-/api/values    [get|post]
+/api/values    [GET|POST]
 
 [BaseUrl]/api/values> echo on
 Request echoing is on
@@ -82,7 +82,7 @@ Using a base address of [BaseUrl]/
 Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
 
 [BaseUrl]/> cd api/values
-/api/values    [get|post]
+/api/values    [GET|POST]
 
 [BaseUrl]/api/values> echo on
 Request echoing is on

--- a/src/Microsoft.HttpRepl.Tests/Commands/ListCommandTests.cs
+++ b/src/Microsoft.HttpRepl.Tests/Commands/ListCommandTests.cs
@@ -164,5 +164,40 @@ namespace Microsoft.HttpRepl.Tests.Commands
 
             Assert.Empty(suggestions);
         }
+
+        [Fact]
+        public async Task ExecuteAsync_WithMethods_MethodsAreUppercase()
+        {
+            string response = @"{
+  ""swagger"": ""2.0"",
+  ""paths"": {
+    ""/api"": {
+      ""get"": {
+      },
+      ""post"": {
+      }
+    }
+  }
+}";
+
+            ArrangeInputs(commandText: "ls",
+                          baseAddress: "http://localhost/",
+                          path: "/api",
+                          urlsWithResponse: new Dictionary<string, string>() { { "http://localhost/swagger.json", response } },
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out _,
+                          out IPreferences preferences);
+
+            httpState.SwaggerEndpoint = new Uri("http://localhost/swagger.json");
+
+            ListCommand listCommand = new ListCommand(preferences);
+
+            await listCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
+
+            string actualOutput = string.Join(Environment.NewLine, shellState.Output);
+            Assert.Contains("[GET|POST]", actualOutput, StringComparison.Ordinal);
+        }
     }
 }

--- a/src/Microsoft.HttpRepl/Commands/ChangeDirectoryCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ChangeDirectoryCommand.cs
@@ -71,7 +71,7 @@ namespace Microsoft.HttpRepl.Commands
                     }
                     else if (hasRequestMethods)
                     {
-                        thisDirMethod = "[" + string.Join("|", s.RequestInfo.Methods) + "]";
+                        thisDirMethod = s.RequestInfo.GetDirectoryMethodListing();
                     }
 
                     shellState.ConsoleManager.WriteLine($"{programState.GetRelativePathString()}    {thisDirMethod}");

--- a/src/Microsoft.HttpRepl/Commands/ListCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ListCommand.cs
@@ -27,7 +27,6 @@ namespace Microsoft.HttpRepl.Commands
             _preferences = preferences;
         }
 
-
         protected override async Task ExecuteAsync(IShellState shellState, HttpState programState, DefaultCommandInput<ICoreParseResult> commandInput, ICoreParseResult parseResult, CancellationToken cancellationToken)
         {
             if (programState.SwaggerEndpoint != null)
@@ -68,9 +67,7 @@ namespace Microsoft.HttpRepl.Commands
 
             IDirectoryStructure s = programState.Structure.TraverseTo(programState.PathSections.Reverse()).TraverseTo(path);
 
-            string thisDirMethod = s.RequestInfo != null && s.RequestInfo.Methods.Count > 0
-                ? "[" + string.Join("|", s.RequestInfo.Methods) + "]"
-                : "[]";
+            string thisDirMethod = s.RequestInfo.GetDirectoryMethodListing();
 
             List<TreeNode> roots = new List<TreeNode>();
             Formatter formatter = new Formatter();
@@ -79,9 +76,7 @@ namespace Microsoft.HttpRepl.Commands
 
             if (s.Parent != null)
             {
-                string parentDirMethod = s.Parent.RequestInfo != null && s.Parent.RequestInfo.Methods.Count > 0
-                    ? "[" + string.Join("|", s.Parent.RequestInfo.Methods) + "]"
-                    : "[]";
+                string parentDirMethod = s.Parent.RequestInfo.GetDirectoryMethodListing();
 
                 roots.Add(new TreeNode(formatter, "..", parentDirMethod));
             }
@@ -104,9 +99,7 @@ namespace Microsoft.HttpRepl.Commands
             {
                 IDirectoryStructure dir = s.GetChildDirectory(child);
 
-                string methods = dir.RequestInfo != null && dir.RequestInfo.Methods.Count > 0 
-                    ? "[" + string.Join("|", dir.RequestInfo.Methods) + "]" 
-                    : "[]";
+                string methods = dir.RequestInfo.GetDirectoryMethodListing();
 
                 TreeNode dirNode = new TreeNode(formatter, child, methods);
                 roots.Add(dirNode);

--- a/src/Microsoft.HttpRepl/Extensions/RequestInfoExtensions.cs
+++ b/src/Microsoft.HttpRepl/Extensions/RequestInfoExtensions.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.HttpRepl
+{
+    public static class RequestInfoExtensions
+    {
+        public static string GetDirectoryMethodListing(this IRequestInfo requestInfo)
+        {
+            if (requestInfo is null || requestInfo.Methods is null || requestInfo.Methods.Count == 0)
+            {
+                return "[]";
+            }
+
+            IEnumerable<string> upperCaseMethods = requestInfo.Methods.Select(s => s?.ToUpperInvariant());
+
+            return "[" + string.Join("|", upperCaseMethods) + "]";
+        }
+    }
+}


### PR DESCRIPTION
Resolves #192 

Since the HTTP spec says verbs are uppercase, we should display them that way. We'll still accept lowercase for the commands