### PR TITLE
Removing the unnecessary list allocation

### DIFF
--- a/src/Microsoft.HttpRepl/Suggestions/HeaderCompletion.cs
+++ b/src/Microsoft.HttpRepl/Suggestions/HeaderCompletion.cs
@@ -65,11 +65,16 @@ namespace Microsoft.HttpRepl.Suggestions
             "X-Correlation-ID"
         };
 
+        /// <summary>
+        /// Gets a collection of HTTP header names which starts with the prefix value passed in, except the ones present in existingHeaders.
+        /// </summary>
+        /// <param name="existingHeaders">A collection of existing headers.</param>
+        /// <param name="prefix">The prefix value to get completion suggestion items for.</param>
+        /// <returns></returns>
         public static IEnumerable<string> GetCompletions(IReadOnlyCollection<string> existingHeaders, string prefix)
         {
             return CommonHeaders.Where(x => x.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
-                                            existingHeaders?.Contains(x) != true)
-                                .ToList();
+                                            existingHeaders?.Contains(x) != true);
         }
 
         public static IEnumerable<string> GetValueCompletions(string method, string path, string header, string prefix, HttpState programState)


### PR DESCRIPTION
The `HeaderCompletion.GetCompletions` method signature has `IEnumerable<string>` as the return type, which is what the `Where` extension method will return. We are currently calling a `ToList` method on top of this `IEnumerable<string>` and returning that from the `GetCompletions` method.  The `ToList()` method call will allocate memory for the new list. It is unnecessary in the case of  `GetCompletions` as the return type of `Where` method call matches with the return type of `GetCompletions`.

I ran benchmarks with both implementations. You can see the code used for benchmarking [here](https://gist.github.com/kshyju/3f8d5777e0d0c34ef173da7c288d82a4)

Here are the numbers

``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.18362
Intel Xeon CPU E5-1650 v4 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=3.0.100-preview9-014004
  [Host]     : .NET Core 2.2.6 (CoreCLR 4.6.27817.03, CoreFX 4.6.27818.02), 64bit RyuJIT
  DefaultJob : .NET Core 2.2.6 (CoreCLR 4.6.27817.03, CoreFX 4.6.27818.02), 64bit RyuJIT


```
|         Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
|    With_ToList | 1.926 us | 0.0248 us | 0.0220 us | 0.0801 |     - |     - |     520 B |
| Without_ToList | 1.629 us | 0.0130 us | 0.0121 us | 0.0210 |     - |     - |     144 B |

