### PR TITLE
Rework ui command to be more flexible

### DIFF
--- a/src/Microsoft.HttpRepl.Tests/Commands/UICommandTests.cs
+++ b/src/Microsoft.HttpRepl.Tests/Commands/UICommandTests.cs
@@ -2,11 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.HttpRepl.Commands;
 using Microsoft.HttpRepl.Fakes;
+using Microsoft.HttpRepl.Preferences;
 using Microsoft.HttpRepl.Resources;
+using Microsoft.HttpRepl.UserProfile;
 using Microsoft.Repl.Parsing;
 using Moq;
 using Xunit;
@@ -18,12 +21,17 @@ namespace Microsoft.HttpRepl.Tests.Commands
         [Fact]
         public void CanHandle_WithNoParseResultSections_ReturnsNull()
         {
-            ArrangeInputs(parseResultSections: string.Empty,
-                out MockedShellState shellState,
-                out HttpState httpState,
-                out ICoreParseResult parseResult);
+            ArrangeInputs(commandText: string.Empty,
+                          baseAddress: null,
+                          path: null,
+                          urlsWithResponse: null,
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out _,
+                          out IPreferences preferences);
 
-            UICommand uiCommand = new UICommand(new UriLauncher());
+            UICommand uiCommand = new UICommand(new UriLauncher(), preferences);
 
             bool? result = uiCommand.CanHandle(shellState, httpState, parseResult);
 
@@ -31,29 +39,39 @@ namespace Microsoft.HttpRepl.Tests.Commands
         }
 
         [Fact]
-        public void CanHandle_WithMoreThanOneParseResultSections_ReturnsNull()
+        public void CanHandle_WithMoreThanOneParseResultSections_ReturnsTrue()
         {
-            ArrangeInputs(parseResultSections: "ui test",
-                out MockedShellState shellState,
-                out HttpState httpState,
-                out ICoreParseResult parseResult);
+            ArrangeInputs(commandText: "ui test",
+                          baseAddress: null,
+                          path: null,
+                          urlsWithResponse: null,
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out _,
+                          out IPreferences preferences);
 
-            UICommand uiCommand = new UICommand(new UriLauncher());
+            UICommand uiCommand = new UICommand(new UriLauncher(), preferences);
 
             bool? result = uiCommand.CanHandle(shellState, httpState, parseResult);
 
-            Assert.Null(result);
+            Assert.True(result);
         }
 
         [Fact]
         public void CanHandle_WithInvalidName_ReturnsNull()
         {
-            ArrangeInputs(parseResultSections: "test",
-                out MockedShellState shellState,
-                out HttpState httpState,
-                out ICoreParseResult parseResult);
+            ArrangeInputs(commandText: "test",
+                          baseAddress: null,
+                          path: null,
+                          urlsWithResponse: null,
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out _,
+                          out IPreferences preferences);
 
-            UICommand uiCommand = new UICommand(new UriLauncher());
+            UICommand uiCommand = new UICommand(new UriLauncher(), preferences);
 
             bool? result = uiCommand.CanHandle(shellState, httpState, parseResult);
 
@@ -63,12 +81,17 @@ namespace Microsoft.HttpRepl.Tests.Commands
         [Fact]
         public void CanHandle_WithValidName_ReturnsTrue()
         {
-            ArrangeInputs(parseResultSections: "ui",
-                out MockedShellState shellState,
-                out HttpState httpState,
-                out ICoreParseResult parseResult);
+            ArrangeInputs(commandText: "ui",
+                          baseAddress: null,
+                          path: null,
+                          urlsWithResponse: null,
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out _,
+                          out IPreferences preferences);
 
-            UICommand uiCommand = new UICommand(new UriLauncher());
+            UICommand uiCommand = new UICommand(new UriLauncher(), preferences);
 
             bool? result = uiCommand.CanHandle(shellState, httpState, parseResult);
 
@@ -78,12 +101,17 @@ namespace Microsoft.HttpRepl.Tests.Commands
         [Fact]
         public void GetHelpSummary_ReturnsHelpSummary()
         {
-            ArrangeInputs(parseResultSections: string.Empty,
-                 out MockedShellState shellState,
-                 out HttpState httpState,
-                 out ICoreParseResult _);
+            ArrangeInputs(commandText: string.Empty,
+                          baseAddress: null,
+                          path: null,
+                          urlsWithResponse: null,
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out _,
+                          out _,
+                          out IPreferences preferences);
 
-            UICommand uiCommand = new UICommand(new UriLauncher());
+            UICommand uiCommand = new UICommand(new UriLauncher(), preferences);
 
             string result = uiCommand.GetHelpSummary(shellState, httpState);
 
@@ -93,27 +121,17 @@ namespace Microsoft.HttpRepl.Tests.Commands
         [Fact]
         public void GetHelpDetails_WithInvalidParseResultSection_ReturnsNull()
         {
-            ArrangeInputs(parseResultSections: "section1",
-                 out MockedShellState shellState,
-                 out HttpState httpState,
-                 out ICoreParseResult parseResult);
+            ArrangeInputs(commandText: "section1",
+                          baseAddress: null,
+                          path: null,
+                          urlsWithResponse: null,
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out _,
+                          out IPreferences preferences);
 
-            UICommand uiCommand = new UICommand(new UriLauncher());
-
-            string result = uiCommand.GetHelpDetails(shellState, httpState, parseResult);
-
-            Assert.Null(result);
-        }
-
-        [Fact]
-        public void GetHelpDetails_WithMoreThanOneParseResultSections_ReturnsNull()
-        {
-            ArrangeInputs(parseResultSections: "ui section1",
-                 out MockedShellState shellState,
-                 out HttpState httpState,
-                 out ICoreParseResult parseResult);
-
-            UICommand uiCommand = new UICommand(new UriLauncher());
+            UICommand uiCommand = new UICommand(new UriLauncher(), preferences);
 
             string result = uiCommand.GetHelpDetails(shellState, httpState, parseResult);
 
@@ -125,11 +143,11 @@ namespace Microsoft.HttpRepl.Tests.Commands
         {
             MockedShellState shellState = new MockedShellState();
             ICoreParseResult parseResult = CoreParseResultHelper.Create("ui");
-            HttpState httpState = GetHttpState(out _, out _);
+            HttpState httpState = GetHttpState(out _, out IPreferences preferences);
             httpState.BaseAddress = null;
 
             Mock<IUriLauncher> mockLauncher = new Mock<IUriLauncher>();
-            UICommand uiCommand = new UICommand(mockLauncher.Object);
+            UICommand uiCommand = new UICommand(mockLauncher.Object, preferences);
 
             await uiCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
 
@@ -139,16 +157,21 @@ namespace Microsoft.HttpRepl.Tests.Commands
         [Fact]
         public async Task ExecuteAsync_WithValidHttpStateBaseAddress_VerifyLaunchUriAsyncWasCalledOnce()
         {
-            ArrangeInputs(parseResultSections: "ui",
-                 out MockedShellState shellState,
-                 out HttpState httpState,
-                 out ICoreParseResult parseResult);
+            ArrangeInputs(commandText: "ui",
+                          baseAddress: null,
+                          path: null,
+                          urlsWithResponse: null,
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out _,
+                          out IPreferences preferences);
 
             Uri uri = new Uri("https://localhost:44366/");
             httpState.BaseAddress = uri;
 
             Mock<IUriLauncher> mockLauncher = new Mock<IUriLauncher>();
-            UICommand uiCommand = new UICommand(mockLauncher.Object);
+            UICommand uiCommand = new UICommand(mockLauncher.Object, preferences);
 
             mockLauncher.Setup(s => s.LaunchUriAsync(It.IsAny<Uri>()))
                 .Returns(Task.CompletedTask);
@@ -161,10 +184,15 @@ namespace Microsoft.HttpRepl.Tests.Commands
         [Fact]
         public async Task ExecuteAsync_WithLaunchUriFailure_ThrowsException()
         {
-            ArrangeInputs(parseResultSections: "ui",
-                 out MockedShellState shellState,
-                 out HttpState httpState,
-                 out ICoreParseResult parseResult);
+            ArrangeInputs(commandText: "ui",
+                          baseAddress: null,
+                          path: null,
+                          urlsWithResponse: null,
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out _,
+                          out IPreferences preferences);
 
             Uri uri = new Uri("https://localhost:44366/");
             httpState.BaseAddress = uri;
@@ -174,11 +202,152 @@ namespace Microsoft.HttpRepl.Tests.Commands
             mockLauncher.Setup(s => s.LaunchUriAsync(It.IsAny<Uri>()))
                 .Returns(Task.FromException(new Exception(expectedErrorMessage)));
 
-            UICommand uiCommand = new UICommand(mockLauncher.Object);
+            UICommand uiCommand = new UICommand(mockLauncher.Object, preferences);
             var exception = await Record.ExceptionAsync(async () => await uiCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None));
 
             Assert.NotNull(exception);
             Assert.Equal(expectedErrorMessage, exception.Message);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithRelativeParameter_VerifyLaunchUriAsyncWasCalledOnce()
+        {
+            ArrangeInputs(commandText: "ui /mySwaggerPath",
+                          baseAddress: "https://localhost:44366/",
+                          path: null,
+                          urlsWithResponse: null,
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out _,
+                          out IPreferences preferences);
+
+            Mock<IUriLauncher> mockLauncher = new Mock<IUriLauncher>();
+            UICommand uiCommand = new UICommand(mockLauncher.Object, preferences);
+
+            mockLauncher.Setup(s => s.LaunchUriAsync(It.IsAny<Uri>()))
+                        .Returns(Task.CompletedTask);
+
+            await uiCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
+
+            mockLauncher.Verify(l => l.LaunchUriAsync(It.Is<Uri>(u => u.AbsoluteUri == "https://localhost:44366/mySwaggerPath")), Times.Once());
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithAbsoluteParameter_VerifyLaunchUriAsyncWasCalledOnce()
+        {
+            ArrangeInputs(commandText: "ui https://localhost:12345/mySwaggerPath",
+                          baseAddress: "https://localhost:44366/",
+                          path: null,
+                          urlsWithResponse: null,
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out _,
+                          out IPreferences preferences);
+
+            Mock<IUriLauncher> mockLauncher = new Mock<IUriLauncher>();
+            UICommand uiCommand = new UICommand(mockLauncher.Object, preferences);
+
+            mockLauncher.Setup(s => s.LaunchUriAsync(It.IsAny<Uri>()))
+                        .Returns(Task.CompletedTask);
+
+            await uiCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
+
+            mockLauncher.Verify(l => l.LaunchUriAsync(It.Is<Uri>(u => u.AbsoluteUri == "https://localhost:12345/mySwaggerPath")), Times.Once());
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithNoParameterAndNoPreference_VerifyLaunchUriAsyncWasCalledOnce()
+        {
+            ArrangeInputs(commandText: "ui",
+                          baseAddress: "https://localhost:44366/",
+                          path: null,
+                          urlsWithResponse: null,
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out _,
+                          out IPreferences preferences);
+
+            Mock<IUriLauncher> mockLauncher = new Mock<IUriLauncher>();
+            UICommand uiCommand = new UICommand(mockLauncher.Object, preferences);
+
+            mockLauncher.Setup(s => s.LaunchUriAsync(It.IsAny<Uri>()))
+                        .Returns(Task.CompletedTask);
+
+            await uiCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
+
+            mockLauncher.Verify(l => l.LaunchUriAsync(It.Is<Uri>(u => u.AbsoluteUri == "https://localhost:44366/swagger")), Times.Once());
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithNoParameterAndRelativePreference_VerifyLaunchUriAsyncWasCalledOnce()
+        {
+            string commandText = "ui";
+            ICoreParseResult parseResult = CoreParseResultHelper.Create(commandText);
+            MockedShellState shellState = new MockedShellState();
+            MockedFileSystem fileSystem = new MockedFileSystem();
+            UserFolderPreferences preferences = new UserFolderPreferences(fileSystem, new UserProfileDirectoryProvider(), null);
+            preferences.SetValue(WellKnownPreference.SwaggerUIEndpoint, "/mySwaggerPath");
+            HttpState httpState = new HttpState(fileSystem, preferences, new HttpClient());
+            httpState.BaseAddress = new Uri("https://localhost:44366", UriKind.Absolute);
+
+            Mock<IUriLauncher> mockLauncher = new Mock<IUriLauncher>();
+            UICommand uiCommand = new UICommand(mockLauncher.Object, preferences);
+
+            mockLauncher.Setup(s => s.LaunchUriAsync(It.IsAny<Uri>()))
+                        .Returns(Task.CompletedTask);
+
+            await uiCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
+
+            mockLauncher.Verify(l => l.LaunchUriAsync(It.Is<Uri>(u => u.AbsoluteUri == "https://localhost:44366/mySwaggerPath")), Times.Once());
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithNoParameterAndAbsolutePreference_VerifyLaunchUriAsyncWasCalledOnce()
+        {
+            string commandText = "ui";
+            ICoreParseResult parseResult = CoreParseResultHelper.Create(commandText);
+            MockedShellState shellState = new MockedShellState();
+            MockedFileSystem fileSystem = new MockedFileSystem();
+            UserFolderPreferences preferences = new UserFolderPreferences(fileSystem, new UserProfileDirectoryProvider(), null);
+            preferences.SetValue(WellKnownPreference.SwaggerUIEndpoint, "https://localhost:12345/mySwaggerPath");
+            HttpState httpState = new HttpState(fileSystem, preferences, new HttpClient());
+            httpState.BaseAddress = new Uri("https://localhost:44366", UriKind.Absolute);
+
+            Mock<IUriLauncher> mockLauncher = new Mock<IUriLauncher>();
+            UICommand uiCommand = new UICommand(mockLauncher.Object, preferences);
+
+            mockLauncher.Setup(s => s.LaunchUriAsync(It.IsAny<Uri>()))
+                        .Returns(Task.CompletedTask);
+
+            await uiCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
+
+            mockLauncher.Verify(l => l.LaunchUriAsync(It.Is<Uri>(u => u.AbsoluteUri == "https://localhost:12345/mySwaggerPath")), Times.Once());
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithInvalidParameterAndNoPreference_DisplaysError()
+        {
+            string invalidParameter = "https:///localhost/swagger";
+            string expectedError = string.Format(Strings.UICommand_InvalidParameter, invalidParameter);
+            ArrangeInputs(commandText: $"ui {invalidParameter}",
+                          baseAddress: "https://localhost:44366/",
+                          path: null,
+                          urlsWithResponse: null,
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out _,
+                          out IPreferences preferences);
+
+            Mock<IUriLauncher> mockLauncher = new Mock<IUriLauncher>();
+            UICommand uiCommand = new UICommand(mockLauncher.Object, preferences);
+
+            await uiCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
+
+            Assert.Equal(expectedError, shellState.ErrorMessage, StringComparer.Ordinal);
         }
     }
 }

--- a/src/Microsoft.HttpRepl/Preferences/WellKnownPreference.cs
+++ b/src/Microsoft.HttpRepl/Preferences/WellKnownPreference.cs
@@ -172,6 +172,8 @@ namespace Microsoft.HttpRepl.Preferences
 
         public static string SwaggerSearchPaths { get; } = "swagger.searchPaths";
 
+        public static string SwaggerUIEndpoint { get; } = "swagger.uiEndpoint";
+
         public static string UseDefaultCredentials { get; } = "httpClient.useDefaultCredentials";
 
         public static string HttpClientUserAgent { get; } = "httpClient.userAgent";

--- a/src/Microsoft.HttpRepl/Program.cs
+++ b/src/Microsoft.HttpRepl/Program.cs
@@ -102,7 +102,7 @@ namespace Microsoft.HttpRepl
             dispatcher.AddCommand(new RunCommand(fileSystem));
             dispatcher.AddCommand(new SetBaseCommand());
             dispatcher.AddCommand(new SetHeaderCommand());
-            dispatcher.AddCommand(new UICommand(new UriLauncher()));
+            dispatcher.AddCommand(new UICommand(new UriLauncher(), preferences));
 
             shell = new Shell(dispatcher, consoleManager: consoleManager);
         }

--- a/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
+++ b/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
@@ -678,6 +678,15 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The parameter &apos;{0}&apos; could not be converted into a valid uri..
+        /// </summary>
+        internal static string UICommand_InvalidParameter {
+            get {
+                return ResourceManager.GetString("UICommand_InvalidParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Must be connected to a server to launch Swagger UI.
         /// </summary>
         internal static string UICommand_NotConnectedToServerError {

--- a/src/Microsoft.HttpRepl/Resources/Strings.resx
+++ b/src/Microsoft.HttpRepl/Resources/Strings.resx
@@ -350,4 +350,8 @@ When +history option is specified, commands specified in the text file will be a
   <data name="SetBaseCommand_MustSpecifyServerError" xml:space="preserve">
     <value>Must specify a server</value>
   </data>
+  <data name="UICommand_InvalidParameter" xml:space="preserve">
+    <value>The parameter '{0}' could not be converted into a valid uri.</value>
+    <comment>{0} is a string parameter to the UI command</comment>
+  </data>
 </root>


### PR DESCRIPTION
Resolves #151.

Previously, the `ui` command just tried to go to a url formed (essentially) from:

```C#
Uri uri = new Uri(baseAddress, swagger);
```

This was limited, for obvious reasons.

This PR adds flexibility in two ways:

1. The `ui` command now takes an optional parameter, where you can specify the absolute or relative (to the base address) swagger endpoint. So, for instance, if your base address is https://localhost:44366/ and your swagger endpoint is https://localhost:44366/mySwaggerEndpoint, you can issue either `ui mySwaggerEndpoint` or `ui https://localhost:44366/mySwaggerEndpoint` and it should launch the correct ui for you.
2. The `ui` command, absent a provided parameter, will attempt to use the `swagger.uiEndpoint` preference, if set, before falling back to the original behavior of trying `swagger`. So you could call `pref set swagger.uiEndpoint mySwaggerEndpoint` and then all subsequent calls to ui (including both in the current session and subsequent sessions) would use that value (with your current base address, since it is a relative value).