### PR TITLE
Renaming assembly from dotnet-httprepl to httprepl

### DIFF
--- a/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
+++ b/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
-    <AssemblyName>dotnet-httprepl</AssemblyName>
+    <AssemblyName>httprepl</AssemblyName>
     <Description>The HTTP Read-Eval-Print Loop (REPL) is a lightweight, cross-platform command-line tool that's supported everywhere .NET Core is supported and is used for making HTTP requests to test ASP.NET Core web APIs and view their results.</Description>
     <PackageId>Microsoft.dotnet-httprepl</PackageId>
     <PackageTags>dotnet;http;httprepl</PackageTags>


### PR DESCRIPTION
This PR changes the name of the assembly from `dotnet-httprepl` to `httprepl`. The effect here is that, once installed, the tool can be run by calling the more succinct `httprepl` instead of the more verbose `dotnet-httprepl`.

Note that by making this change we can no longer run the tool by calling `dotnet httprepl` (note the space). But since we already have a shortened way to do it, there's no harm there.

Also note that everything I said above refers to its usage as a global tool. If it's installed as a local tool, `dotnet-httprepl` (previously) and `httprepl` (with this PR) never worked anyway. Local tools require that you call it via the `dotnet` tool. In this case, `dotnet httprepl` still works.

cc @shanselman since you brought this up with me earlier