### PR TITLE
Adding in-app documentation for the ui command

### DIFF
--- a/src/Microsoft.HttpRepl/Commands/UICommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/UICommand.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.HttpRepl.Preferences;
@@ -82,11 +83,37 @@ namespace Microsoft.HttpRepl.Commands
             return _uriLauncher.LaunchUriAsync(uri);
         }
 
+        private string _HelpText;
+        private string HelpText
+        {
+            get
+            {
+                if (_HelpText is null)
+                {
+                    string parameter = "{swaggerUIAddress}";
+                    string defaultAddress = "[BaseAddress]/swagger";
+                    var helpText = new StringBuilder();
+                    helpText.Append(Strings.Usage.Bold());
+                    helpText.AppendLine("ui [{swaggerUIAddress}]");
+                    helpText.AppendLine();
+                    helpText.AppendLine(Strings.UICommand_Description);
+                    helpText.AppendLine();
+                    helpText.AppendLine(string.Format(Strings.UICommand_HelpText_Line1, Name));
+                    helpText.AppendLine(string.Format(Strings.UICommand_HelpText_Line2, parameter));
+                    helpText.AppendLine(string.Format(Strings.UICommand_HelpText_Line3, WellKnownPreference.SwaggerUIEndpoint));
+                    helpText.AppendLine(string.Format(Strings.UICommand_HelpText_Line4, defaultAddress));
+
+                    _HelpText = helpText.ToString();
+                }
+                return _HelpText;
+            }
+        }
+
         public string GetHelpDetails(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
         {
             if (parseResult.ContainsAtLeast(Name))
             {
-                return Strings.UICommand_Description;
+                return HelpText;
             }
 
             return null;

--- a/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
+++ b/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
@@ -669,7 +669,7 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ui - Launches the Swagger UI page (if available) in the default browser.
+        ///   Looks up a localized string similar to Launches the Swagger UI page (if available) in the default browser.
         /// </summary>
         internal static string UICommand_Description {
             get {
@@ -683,6 +683,42 @@ namespace Microsoft.HttpRepl.Resources {
         internal static string UICommand_HelpSummary {
             get {
                 return ResourceManager.GetString("UICommand_HelpSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The {0} command uses multiple sources to determine the swagger ui endpoint. In order of precedence:.
+        /// </summary>
+        internal static string UICommand_HelpText_Line1 {
+            get {
+                return ResourceManager.GetString("UICommand_HelpText_Line1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to   1. The {0} parameter, if specified.
+        /// </summary>
+        internal static string UICommand_HelpText_Line2 {
+            get {
+                return ResourceManager.GetString("UICommand_HelpText_Line2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to   2. The {0} preference, if set.
+        /// </summary>
+        internal static string UICommand_HelpText_Line3 {
+            get {
+                return ResourceManager.GetString("UICommand_HelpText_Line3", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to   3. A default url of {0}.
+        /// </summary>
+        internal static string UICommand_HelpText_Line4 {
+            get {
+                return ResourceManager.GetString("UICommand_HelpText_Line4", resourceCulture);
             }
         }
         

--- a/src/Microsoft.HttpRepl/Resources/Strings.resx
+++ b/src/Microsoft.HttpRepl/Resources/Strings.resx
@@ -220,7 +220,7 @@
     <value>Must specify a swagger document</value>
   </data>
   <data name="UICommand_Description" xml:space="preserve">
-    <value>ui - Launches the Swagger UI page (if available) in the default browser</value>
+    <value>Launches the Swagger UI page (if available) in the default browser</value>
   </data>
   <data name="UICommand_NotConnectedToServerError" xml:space="preserve">
     <value>Must be connected to a server to launch Swagger UI</value>
@@ -357,5 +357,21 @@ When +history option is specified, commands specified in the text file will be a
   <data name="UICommand_InvalidParameter" xml:space="preserve">
     <value>The parameter '{0}' could not be converted into a valid uri.</value>
     <comment>{0} is a string parameter to the UI command</comment>
+  </data>
+  <data name="UICommand_HelpText_Line1" xml:space="preserve">
+    <value>The {0} command uses multiple sources to determine the swagger ui endpoint. In order of precedence:</value>
+    <comment>{0} is the name of the ui command (ui)</comment>
+  </data>
+  <data name="UICommand_HelpText_Line2" xml:space="preserve">
+    <value>  1. The {0} parameter, if specified</value>
+    <comment>{0} is the syntax for the parameter, e.g. {swaggerUIAddress}</comment>
+  </data>
+  <data name="UICommand_HelpText_Line3" xml:space="preserve">
+    <value>  2. The {0} preference, if set</value>
+    <comment>{0} is the name of the preference, e.g. swagger.uiEndpoint</comment>
+  </data>
+  <data name="UICommand_HelpText_Line4" xml:space="preserve">
+    <value>  3. A default url of {0}</value>
+    <comment>{0} is the default address, e.g. [BaseAddress]/swagger</comment>
   </data>
 </root>

--- a/src/Microsoft.HttpRepl/Resources/Strings.resx
+++ b/src/Microsoft.HttpRepl/Resources/Strings.resx
@@ -359,7 +359,7 @@ When +history option is specified, commands specified in the text file will be a
     <comment>{0} is a string parameter to the UI command</comment>
   </data>
   <data name="UICommand_HelpText_Line1" xml:space="preserve">
-    <value>The {0} command uses multiple sources to determine the swagger ui endpoint. In order of precedence:</value>
+    <value>The {0} command uses multiple sources to determine the Swagger UI endpoint. In order of precedence:</value>
     <comment>{0} is the name of the ui command (ui)</comment>
   </data>
   <data name="UICommand_HelpText_Line2" xml:space="preserve">

--- a/src/Microsoft.HttpRepl/Resources/Strings.resx
+++ b/src/Microsoft.HttpRepl/Resources/Strings.resx
@@ -371,7 +371,7 @@ When +history option is specified, commands specified in the text file will be a
     <comment>{0} is the name of the preference, e.g. swagger.uiEndpoint</comment>
   </data>
   <data name="UICommand_HelpText_Line4" xml:space="preserve">
-    <value>  3. A default url of {0}</value>
+    <value>  3. A default URL of {0}</value>
     <comment>{0} is the default address, e.g. [BaseAddress]/swagger</comment>
   </data>
 </root>


### PR DESCRIPTION
When we pulled #209 we forgot to include in-app documentation on the new flexibility of the `ui` command. This PR adds that documentation. 

The output will now be:

```console
Usage: ui [{swaggerUIAddress}]                                                                                          
Launches the Swagger UI page (if available) in the default browser

The ui command uses multiple sources to determine the swagger ui endpoint. In order of precedence:
  1. The {swaggerUIAddress} parameter, if specified
  2. The swagger.uiEndpoint preference, if set
  3. A default url of [BaseAddress]/swagger
```

@scottaddie Thoughts on this? I figure this can be the basis for the changes to the docs once we settle on it here.