### PR TITLE
Changes for 3.0 release.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,8 +5,6 @@
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>
   <PropertyGroup>
-    <MajorVersion>3</MajorVersion>
-    <MinorVersion>0</MinorVersion>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <VersionPrefix>3.0.0</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview9-014004"
+    "dotnet": "3.0.100"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.19470.9"

--- a/src/Microsoft.Repl/Microsoft.Repl.csproj
+++ b/src/Microsoft.Repl/Microsoft.Repl.csproj
@@ -8,6 +8,7 @@
     <PackageIcon>PackageIcon.png</PackageIcon>
     
     <IsPackable>true</IsPackable>
+    <IsShipping>false</IsShipping>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The changes needed to build the 3.0 release with the .net core 3.0 sdk. This probably won't build yet since the SDK pieces aren't on nuget yet.