### PR TITLE
Update version for 3.1 previews

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,6 +5,9 @@
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <MajorVersion>3</MajorVersion>
+    <MinorVersion>1</MinorVersion>
+    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <DotNetFinalVersionKind>prerelease</DotNetFinalVersionKind>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,9 +5,7 @@
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>
   <PropertyGroup>
-    <MajorVersion>3</MajorVersion>
-    <MinorVersion>1</MinorVersion>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <DotNetFinalVersionKind>prerelease</DotNetFinalVersionKind>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Setting up `master` to start building 3.1.0-preview-* builds going forward.
Attempting to straight this out based on the [Arcade versioning guidelines](https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md). It recommends we do release-only, but we're not going that route at the moment. 
That part aside, we'll be leaving the `<PreReleaseVersionLabel>` value in the code, and when we need to release, we'll override it by setting `DotNetFinalVersionKind` to `release` in the build pipeline. 
This should mean we have all of our preview packages the same as they have been (e.g. 3.1.0-preview-XXXXX.X) and the release package will just drop the prerelease label, not change the `patch` version. 

Note that for 3.0-era patches, we'll need to continue the same semi-broken versioning and have the bug fixes be something higher than 3.0.47301 (which will automatically happen as long as we branch from a commit between f9b9ee2807e948a804bb4dab69d4b517a1503a39 and when this PR goes in.