### PR TITLE
Updating the YAML CI triggers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,10 +25,29 @@ resources:
     options: --init # This ensures all the stray defunct processes are reaped.
 
 trigger:
-- master
+  branches:
+    include:
+    - master
+    - release/*
+  paths:
+    include:
+    - /
+    exclude:
+    - CONTRIBUTING.md
+    - README.md
+    - SECURITY.md
 
 pr:
-- "*"
+  branches:
+    include:
+    - "*"
+  paths:
+    include:
+    - /
+    exclude:
+    - CONTRIBUTING.md
+    - README.md
+    - SECURITY.md
 
 stages:
 - stage: build


### PR DESCRIPTION
Changes the CI Trigger to:
- Include `release/*` branches (for instance, 3.0 bug fix releases branched from master)
- Exclude the `.md` files in the root that don't need to trigger a build

Changes the PR trigger to exclude the `.md` files in the root that don't need to trigger a build.

Includes are processed first, so we need to include all paths first, then exclude the couple of files we don't want. Just excluding them would mean it'd never get triggered. 

`release/*` is used rather than `rel/*` because the former is what is registered in the Maestro subscription.