### PR TITLE
Add DotNetPublishUsingPipelines parameter

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,6 +105,7 @@ stages:
             -prepareMachine
             -integrationTest
             $(_BuildArgs)
+            /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
           name: Build
           displayName: Build
           condition: succeeded()


### PR DESCRIPTION
Adding this parameter to fix the build errors, per https://github.com/dotnet/arcade/commit/df24cd9b34682b5509df5a08ef8a8952e5a4f623, https://github.com/dotnet/extensions/pull/3016 and https://github.com/dotnet/aspnetcore-tooling/pull/1622.