### PR TITLE
Switching to the latest macOS image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -137,7 +137,7 @@ stages:
 
       - job: macOS
         pool:
-          vmImage: macOS-10.13
+          vmImage: macOS-10.15
         strategy:
           matrix:
             debug:


### PR DESCRIPTION
Per https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/, we need to move off the `macOS-10.13` image to a newer one. `macOS-10.15` should be available, so we'll move to that.