### PR TITLE
Swagger Cleanup

### DIFF
--- a/src/Microsoft.HttpRepl/ApiConnection.cs
+++ b/src/Microsoft.HttpRepl/ApiConnection.cs
@@ -18,7 +18,7 @@ namespace Microsoft.HttpRepl
     internal class ApiConnection
     {
         private readonly IPreferences _preferences;
-        private const string SwaggerSearchPaths = "swagger.json|swagger/v1/swagger.json|/swagger.json|/swagger/v1/swagger.json";
+        private const string SwaggerSearchPaths = "swagger.json|swagger/v1/swagger.json|openapi.json|/swagger.json|/swagger/v1/swagger.json|/openapi.json";
 
         public Uri RootUri { get; set; }
         public bool HasRootUri => RootUri is object;

--- a/src/Microsoft.HttpRepl/Commands/ConnectCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ConnectCommand.cs
@@ -40,7 +40,8 @@ namespace Microsoft.HttpRepl.Commands
                                                                                                                                    requiresValue: true,
                                                                                                                                    minimumOccurrences: 0,
                                                                                                                                    maximumOccurrences: 1,
-                                                                                                                                   forms: new[] { "--swagger", "-s" }))
+                                                                                                                                   forms: new[] { "--openapi", "-o",
+                                                                                                                                                  "--swagger", "-s" }))
                                                                                         .Finish();
 
         public override string GetHelpSummary(IShellState shellState, HttpState programState)
@@ -54,7 +55,7 @@ namespace Microsoft.HttpRepl.Commands
             {
                 var helpText = new StringBuilder();
                 helpText.Append(Resources.Strings.Usage.Bold());
-                helpText.AppendLine("connect [rootAddress] [--base baseAddress] [--swagger swaggerAddress]");
+                helpText.AppendLine("connect [rootAddress] [--base baseAddress] [--openapi openApiDescriptionAddress]");
                 helpText.AppendLine();
                 helpText.AppendLine(Resources.Strings.ConnectCommand_HelpDetails_Line1);
                 helpText.AppendLine();
@@ -227,6 +228,6 @@ namespace Microsoft.HttpRepl.Commands
             return null;
         }
 
-        
+
     }
 }

--- a/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
+++ b/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
@@ -88,7 +88,7 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Warning: The &apos;{0}&apos; endpoint is not present in the Swagger metadata.
+        ///   Looks up a localized string similar to Warning: The &apos;{0}&apos; endpoint is not present in the OpenAPI description.
         /// </summary>
         internal static string ChangeDirectoryCommand_Warning_UnknownEndpoint {
             get {
@@ -124,7 +124,7 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The swagger address must be a valid absolute url or relative url. If it is a relative url, the root address must be specified.
+        ///   Looks up a localized string similar to The OpenAPI description address must be a valid absolute url or relative url. If it is a relative url, the root address must be specified.
         /// </summary>
         internal static string ConnectCommand_Error_InvalidSwagger {
             get {
@@ -142,7 +142,7 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If no root address is specified, the swagger address must be an absolute url, including scheme.
+        ///   Looks up a localized string similar to If no root address is specified, the OpenAPI description address must be an absolute url, including scheme.
         /// </summary>
         internal static string ConnectCommand_Error_NoRootNoAbsoluteSwagger {
             get {
@@ -151,7 +151,7 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You must specify either a root address or a base address and a swagger address.
+        ///   Looks up a localized string similar to You must specify either a root address or a base address and an OpenAPI description address.
         /// </summary>
         internal static string ConnectCommand_Error_NothingSpecified {
             get {
@@ -169,7 +169,7 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Configures the directory structure and base address of the api server based on the arguments and options specified. At least one of [rootAddress], [--base baseAddress] or [--swagger swaggerAddress] must be specified.
+        ///   Looks up a localized string similar to Configures the directory structure and base address of the api server based on the arguments and options specified. At least one of [rootAddress], [--base baseAddress] or [--openapi openApiDescriptionAddress] must be specified.
         /// </summary>
         internal static string ConnectCommand_HelpDetails_Line1 {
             get {
@@ -178,7 +178,7 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [rootAddress] will be used to automatically determine the base address and swagger address.
+        ///   Looks up a localized string similar to [rootAddress] will be used to automatically determine the base address and OpenAPI description address.
         /// </summary>
         internal static string ConnectCommand_HelpDetails_Line2 {
             get {
@@ -187,7 +187,7 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [--base baseAddress] and [--swagger swaggerAddress] allow you to explicitly set those addresses and skip auto detection.
+        ///   Looks up a localized string similar to [--base baseAddress] and [--openapi openApiDescriptionAddress] allow you to explicitly set those addresses and skip auto detection.
         /// </summary>
         internal static string ConnectCommand_HelpDetails_Line3 {
             get {
@@ -214,7 +214,7 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to find a swagger definition.
+        ///   Looks up a localized string similar to Unable to find an OpenAPI description.
         /// </summary>
         internal static string ConnectCommand_Status_NoSwagger {
             get {
@@ -223,7 +223,7 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Using swagger definition at {0}.
+        ///   Looks up a localized string similar to Using OpenAPI description at {0}.
         /// </summary>
         internal static string ConnectCommand_Status_Swagger {
             get {

--- a/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
+++ b/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
@@ -457,7 +457,7 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No directory structure has been set, so there is nothing to list. Use the &quot;set swagger&quot; command to set a directory structure based on a swagger definition..
+        ///   Looks up a localized string similar to No directory structure has been set, so there is nothing to list. Use the &quot;connect&quot; command to set a directory structure based on an OpenAPI description..
         /// </summary>
         internal static string ListCommand_Error_NoDirectoryStructure {
             get {
@@ -665,42 +665,6 @@ namespace Microsoft.HttpRepl.Resources {
         internal static string SetHeaderCommand_HelpSummary {
             get {
                 return ResourceManager.GetString("SetHeaderCommand_HelpSummary", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Sets the swagger document to use for information about the current server.
-        /// </summary>
-        internal static string SetSwaggerCommand_Description {
-            get {
-                return ResourceManager.GetString("SetSwaggerCommand_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Set the URI, relative to your base if set, of the Swagger document for this API. e.g. `set swagger /swagger/v1/swagger.json`.
-        /// </summary>
-        internal static string SetSwaggerCommand_HelpSummary {
-            get {
-                return ResourceManager.GetString("SetSwaggerCommand_HelpSummary", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Must specify a valid swagger document.
-        /// </summary>
-        internal static string SetSwaggerCommand_InvalidSwaggerUri {
-            get {
-                return ResourceManager.GetString("SetSwaggerCommand_InvalidSwaggerUri", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Must specify a swagger document.
-        /// </summary>
-        internal static string SetSwaggerCommand_SpecifySwaggerDocument {
-            get {
-                return ResourceManager.GetString("SetSwaggerCommand_SpecifySwaggerDocument", resourceCulture);
             }
         }
         

--- a/src/Microsoft.HttpRepl/Resources/Strings.resx
+++ b/src/Microsoft.HttpRepl/Resources/Strings.resx
@@ -207,17 +207,8 @@
   <data name="SetHeaderCommand_HelpSummary" xml:space="preserve">
     <value>Sets or clears a header for all requests. e.g. `set header content-type application/json`</value>
   </data>
-  <data name="SetSwaggerCommand_HelpSummary" xml:space="preserve">
-    <value>Set the URI, relative to your base if set, of the Swagger document for this API. e.g. `set swagger /swagger/v1/swagger.json`</value>
-  </data>
   <data name="UICommand_HelpSummary" xml:space="preserve">
     <value>Displays the Swagger UI page, if available, in the default browser</value>
-  </data>
-  <data name="SetSwaggerCommand_Description" xml:space="preserve">
-    <value>Sets the swagger document to use for information about the current server</value>
-  </data>
-  <data name="SetSwaggerCommand_SpecifySwaggerDocument" xml:space="preserve">
-    <value>Must specify a swagger document</value>
   </data>
   <data name="UICommand_Description" xml:space="preserve">
     <value>Launches the Swagger UI page (if available) in the default browser</value>
@@ -255,10 +246,7 @@ When +history option is specified, commands specified in the text file will be a
     <value>No base address has been set, so there is nothing to list. Use the "set base" command to set a base address.</value>
   </data>
   <data name="ListCommand_Error_NoDirectoryStructure" xml:space="preserve">
-    <value>No directory structure has been set, so there is nothing to list. Use the "set swagger" command to set a directory structure based on a swagger definition.</value>
-  </data>
-  <data name="SetSwaggerCommand_InvalidSwaggerUri" xml:space="preserve">
-    <value>Must specify a valid swagger document</value>
+    <value>No directory structure has been set, so there is nothing to list. Use the "connect" command to set a directory structure based on an OpenAPI description.</value>
   </data>
   <data name="ConnectCommand_Error_InvalidBase" xml:space="preserve">
     <value>The base address must be a valid absolute url or relative url. If it is a relative url, the root address must be specified</value>

--- a/src/Microsoft.HttpRepl/Resources/Strings.resx
+++ b/src/Microsoft.HttpRepl/Resources/Strings.resx
@@ -121,7 +121,7 @@
     <value>Append the given directory to the currently selected path, or move up a path when using `cd ..`</value>
   </data>
   <data name="ChangeDirectoryCommand_Warning_UnknownEndpoint" xml:space="preserve">
-    <value>Warning: The '{0}' endpoint is not present in the Swagger metadata</value>
+    <value>Warning: The '{0}' endpoint is not present in the OpenAPI description</value>
     <comment>{0} is the path to the referenced endpoint</comment>
   </data>
   <data name="ClearCommand_HelpSummary" xml:space="preserve">
@@ -252,16 +252,16 @@ When +history option is specified, commands specified in the text file will be a
     <value>The base address must be a valid absolute url or relative url. If it is a relative url, the root address must be specified</value>
   </data>
   <data name="ConnectCommand_Error_InvalidSwagger" xml:space="preserve">
-    <value>The swagger address must be a valid absolute url or relative url. If it is a relative url, the root address must be specified</value>
+    <value>The OpenAPI description address must be a valid absolute url or relative url. If it is a relative url, the root address must be specified</value>
   </data>
   <data name="ConnectCommand_Error_NoRootNoAbsoluteBase" xml:space="preserve">
     <value>If no root address is specified, the base address must be an absolute url, including scheme</value>
   </data>
   <data name="ConnectCommand_Error_NoRootNoAbsoluteSwagger" xml:space="preserve">
-    <value>If no root address is specified, the swagger address must be an absolute url, including scheme</value>
+    <value>If no root address is specified, the OpenAPI description address must be an absolute url, including scheme</value>
   </data>
   <data name="ConnectCommand_Error_NothingSpecified" xml:space="preserve">
-    <value>You must specify either a root address or a base address and a swagger address</value>
+    <value>You must specify either a root address or a base address and an OpenAPI description address</value>
   </data>
   <data name="ConnectCommand_Error_RootAddressNotValid" xml:space="preserve">
     <value>If specified, the root address must be a valid absolute url, including scheme</value>
@@ -274,23 +274,23 @@ When +history option is specified, commands specified in the text file will be a
     <value>Unable to determine a base address</value>
   </data>
   <data name="ConnectCommand_Status_Swagger" xml:space="preserve">
-    <value>Using swagger definition at {0}</value>
+    <value>Using OpenAPI description at {0}</value>
     <comment>{0} indicates a uri</comment>
   </data>
   <data name="ConnectCommand_Status_NoSwagger" xml:space="preserve">
-    <value>Unable to find a swagger definition</value>
+    <value>Unable to find an OpenAPI description</value>
   </data>
   <data name="ConnectCommand_Description" xml:space="preserve">
     <value>Configures the directory structure and base address of the api server</value>
   </data>
   <data name="ConnectCommand_HelpDetails_Line1" xml:space="preserve">
-    <value>Configures the directory structure and base address of the api server based on the arguments and options specified. At least one of [rootAddress], [--base baseAddress] or [--swagger swaggerAddress] must be specified</value>
+    <value>Configures the directory structure and base address of the api server based on the arguments and options specified. At least one of [rootAddress], [--base baseAddress] or [--openapi openApiDescriptionAddress] must be specified</value>
   </data>
   <data name="ConnectCommand_HelpDetails_Line2" xml:space="preserve">
-    <value>[rootAddress] will be used to automatically determine the base address and swagger address</value>
+    <value>[rootAddress] will be used to automatically determine the base address and OpenAPI description address</value>
   </data>
   <data name="ConnectCommand_HelpDetails_Line3" xml:space="preserve">
-    <value>[--base baseAddress] and [--swagger swaggerAddress] allow you to explicitly set those addresses and skip auto detection</value>
+    <value>[--base baseAddress] and [--openapi openApiDescriptionAddress] allow you to explicitly set those addresses and skip auto detection</value>
   </data>
   <data name="HelpCommand_Core_CustomizationCommands" xml:space="preserve">
     <value>REPL Customization Commands:</value>

--- a/test/Microsoft.HttpRepl.IntegrationTests/Commands/ChangeDirectoryCommandTests.cs
+++ b/test/Microsoft.HttpRepl.IntegrationTests/Commands/ChangeDirectoryCommandTests.cs
@@ -29,7 +29,7 @@ cd Values";
             // make sure to normalize newlines in the expected output
             string expected = NormalizeOutput(@"(Disconnected)> connect [BaseUrl]
 Using a base address of [BaseUrl]/
-Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
+Using OpenAPI description at [BaseUrl]/swagger/v1/swagger.json
 
 [BaseUrl]/> ls
 .     []

--- a/test/Microsoft.HttpRepl.IntegrationTests/Commands/GetCommandTests.cs
+++ b/test/Microsoft.HttpRepl.IntegrationTests/Commands/GetCommandTests.cs
@@ -27,7 +27,7 @@ get";
 
             string expected = NormalizeOutput(@"(Disconnected)> connect [BaseUrl]
 Using a base address of [BaseUrl]/
-Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
+Using OpenAPI description at [BaseUrl]/swagger/v1/swagger.json
 
 [BaseUrl]/> cd api/values
 /api/values    [GET|POST]
@@ -61,7 +61,7 @@ get 5";
 
             string expected = NormalizeOutput(@"(Disconnected)> connect [BaseUrl]
 Using a base address of [BaseUrl]/
-Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
+Using OpenAPI description at [BaseUrl]/swagger/v1/swagger.json
 
 [BaseUrl]/> cd api/values
 /api/values    [GET|POST]
@@ -92,10 +92,10 @@ get";
 
             string expected = NormalizeOutput(@"(Disconnected)> connect [BaseUrl]
 Using a base address of [BaseUrl]/
-Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
+Using OpenAPI description at [BaseUrl]/swagger/v1/swagger.json
 
 [BaseUrl]/> cd api/invalidpath
-Warning: The '/api/invalidpath' endpoint is not present in the Swagger metadata
+Warning: The '/api/invalidpath' endpoint is not present in the OpenAPI description
 /api/invalidpath    []
 
 [BaseUrl]/api/invalidpath> get

--- a/test/Microsoft.HttpRepl.IntegrationTests/Commands/ListCommandTests.cs
+++ b/test/Microsoft.HttpRepl.IntegrationTests/Commands/ListCommandTests.cs
@@ -30,7 +30,7 @@ ls";
             // make sure to normalize newlines in the expected output
             string expected = NormalizeOutput(@"(Disconnected)> connect [BaseUrl]
 Using a base address of [BaseUrl]/
-Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
+Using OpenAPI description at [BaseUrl]/swagger/v1/swagger.json
 
 [BaseUrl]/> ls
 .     []
@@ -59,7 +59,7 @@ ls";
 
             string expected = NormalizeOutput(@"(Disconnected)> connect [BaseUrl]
 Using a base address of [BaseUrl]/
-Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
+Using OpenAPI description at [BaseUrl]/swagger/v1/swagger.json
 
 [BaseUrl]/> cd api/Values
 /api/Values    [GET|POST]

--- a/test/Microsoft.HttpRepl.IntegrationTests/Commands/ListCommandTests.cs
+++ b/test/Microsoft.HttpRepl.IntegrationTests/Commands/ListCommandTests.cs
@@ -87,12 +87,12 @@ ls";
             string expected = NormalizeOutput(@"(Disconnected)> set base [BaseUrl]
 
 [BaseUrl]/> ls
-No directory structure has been set, so there is nothing to list. Use the ""set swagger"" command to set a directory structure based on a swagger definition.
+No directory structure has been set, so there is nothing to list. Use the ""connect"" command to set a directory structure based on an OpenAPI description.
 
 [BaseUrl]/> cd api
 
 [BaseUrl]/api> ls
-No directory structure has been set, so there is nothing to list. Use the ""set swagger"" command to set a directory structure based on a swagger definition.
+No directory structure has been set, so there is nothing to list. Use the ""connect"" command to set a directory structure based on an OpenAPI description.
 
 [BaseUrl]/api>", null);
 
@@ -112,7 +112,7 @@ ls";
 [BaseUrl]/> cd api/Values
 
 [BaseUrl]/api/Values> ls
-No directory structure has been set, so there is nothing to list. Use the ""set swagger"" command to set a directory structure based on a swagger definition.
+No directory structure has been set, so there is nothing to list. Use the ""connect"" command to set a directory structure based on an OpenAPI description.
 
 [BaseUrl]/api/Values>", null);
 

--- a/test/Microsoft.HttpRepl.IntegrationTests/Commands/SetHeaderCommandTests.cs
+++ b/test/Microsoft.HttpRepl.IntegrationTests/Commands/SetHeaderCommandTests.cs
@@ -29,7 +29,7 @@ get";
 
             string expected = NormalizeOutput(@"(Disconnected)> connect [BaseUrl]
 Using a base address of [BaseUrl]/
-Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
+Using OpenAPI description at [BaseUrl]/swagger/v1/swagger.json
 
 [BaseUrl]/> cd api/values
 /api/values    [GET|POST]
@@ -79,7 +79,7 @@ get";
 
             string expected = NormalizeOutput(@"(Disconnected)> connect [BaseUrl]
 Using a base address of [BaseUrl]/
-Using swagger definition at [BaseUrl]/swagger/v1/swagger.json
+Using OpenAPI description at [BaseUrl]/swagger/v1/swagger.json
 
 [BaseUrl]/> cd api/values
 /api/values    [GET|POST]

--- a/test/Microsoft.HttpRepl.Tests/Commands/ConnectCommandTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/Commands/ConnectCommandTests.cs
@@ -354,6 +354,92 @@ namespace Microsoft.HttpRepl.Tests.Commands
         }
 
         [Fact]
+        public async Task ExecuteAsync_WithRootAndBase_FindsOpenApiFromRoot()
+        {
+            string rootAddress = "https://localhost/";
+            string baseAddress = "https://localhost/v2/";
+            string swaggerAddress = "https://localhost/openapi.json";
+            string swaggerContent = @"{
+  ""openapi"": ""3.0.0"",
+  ""info"": {
+    ""version"": ""v1""
+  },
+  ""servers"": [
+    {
+      ""url"": ""https://example.com/"",
+      ""description"": ""First Server Address""
+    }
+  ],
+  ""paths"": {
+    ""/pets"": {
+    }
+  }
+}";
+            ArrangeInputs(commandText: $"connect {rootAddress} --base {baseAddress}",
+                          baseAddress: null,
+                          path: null,
+                          urlsWithResponse: new Dictionary<string, string>() { { swaggerAddress, swaggerContent } },
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out _,
+                          out IPreferences preferences);
+
+            ConnectCommand connectCommand = new ConnectCommand(preferences);
+
+            await connectCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
+
+            Assert.NotNull(httpState.BaseAddress);
+            Assert.Equal(baseAddress, httpState.BaseAddress.ToString());
+            Assert.NotNull(httpState.SwaggerEndpoint);
+            Assert.Equal(swaggerAddress, httpState.SwaggerEndpoint.ToString());
+            Assert.NotNull(httpState.ApiDefinition);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithRootAndBase_FindsOpenApiFromBase()
+        {
+            string rootAddress = "https://localhost/";
+            string baseAddress = "https://localhost/v2/";
+            string swaggerAddress = "https://localhost/v2/openapi.json";
+            string swaggerContent = @"{
+  ""openapi"": ""3.0.0"",
+  ""info"": {
+    ""version"": ""v1""
+  },
+  ""servers"": [
+    {
+      ""url"": ""https://example.com/"",
+      ""description"": ""First Server Address""
+    }
+  ],
+  ""paths"": {
+    ""/pets"": {
+    }
+  }
+}";
+            ArrangeInputs(commandText: $"connect {rootAddress} --base {baseAddress}",
+                          baseAddress: null,
+                          path: null,
+                          urlsWithResponse: new Dictionary<string, string>() { { swaggerAddress, swaggerContent } },
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out _,
+                          out IPreferences preferences);
+
+            ConnectCommand connectCommand = new ConnectCommand(preferences);
+
+            await connectCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
+
+            Assert.NotNull(httpState.BaseAddress);
+            Assert.Equal(baseAddress, httpState.BaseAddress.ToString());
+            Assert.NotNull(httpState.SwaggerEndpoint);
+            Assert.Equal(swaggerAddress, httpState.SwaggerEndpoint.ToString());
+            Assert.NotNull(httpState.ApiDefinition);
+        }
+
+        [Fact]
         public async Task ExecuteAsync_WithRootAndSwaggerWithoutBase_SetsBaseToRoot()
         {
             string rootAddress = "https://localhost/";

--- a/test/Microsoft.HttpRepl.Tests/Commands/ConnectCommandTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/Commands/ConnectCommandTests.cs
@@ -80,6 +80,22 @@ namespace Microsoft.HttpRepl.Tests.Commands
         }
 
         [Fact]
+        public async Task ExecuteAsync_WithNoRootAndRelativeOpenApi_ShowsError()
+        {
+            ArrangeInputs("connect --openapi /v1/openapi.json",
+                          out MockedShellState shellState,
+                          out HttpState httpState,
+                          out ICoreParseResult parseResult,
+                          out IPreferences preferences);
+
+            ConnectCommand connectCommand = new ConnectCommand(preferences);
+
+            await connectCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
+
+            Assert.Equal(Resources.Strings.ConnectCommand_Error_NoRootNoAbsoluteSwagger, shellState.ErrorMessage);
+        }
+
+        [Fact]
         public async Task ExecuteAsync_WithRootAndNoBase_SetsBaseToRoot()
         {
             string rootAddress = "https://localhost/";


### PR DESCRIPTION
Three small commits in this PR:

1. Cleans up some leftover references to the old `set swagger` command that no longer existed when we introduced the `connect` command.
2. Adds `--openapi` and `-o` as the preferred ways of specifying the OpenAPI description document. This addresses #346. `--swagger` is still left as an option, but this removes it from (most of) the documentation. We can probably deprecate it when we get to 4.0.
3. Adds `openapi.json` and `/openapi.json` to the search paths for auto discovery of the OpenAPI description url. THis addresses #248. 

cc @darrelmiller since I can't seem to add you as a reviewer.