### PR TITLE
Don't duplicate headers

### DIFF
--- a/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
@@ -136,12 +136,20 @@ namespace Microsoft.HttpRepl.Commands
 
                 foreach (KeyValuePair<string, IEnumerable<string>> header in programState.Headers)
                 {
-                    request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    // We only want to add headers that are not content headers
+                    if (!WellKnownHeaders.ContentHeaders.Contains(header.Key, StringComparer.OrdinalIgnoreCase))
+                    {
+                        request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
                 }
 
                 foreach (KeyValuePair<string, string> header in thisRequestHeaders)
                 {
-                    request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    // We only want to add headers that are not content headers
+                    if (!WellKnownHeaders.ContentHeaders.Contains(header.Key, StringComparer.OrdinalIgnoreCase))
+                    {
+                        request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
                 }
 
                 var responseFileOption = commandInput.Options[ResponseFileOption].Any() ? commandInput.Options[ResponseFileOption][0] : null;
@@ -281,12 +289,22 @@ namespace Microsoft.HttpRepl.Commands
         {
             foreach (KeyValuePair<string, IEnumerable<string>> header in programState.Headers)
             {
-                content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                // We only want to add content headers, except for Content-Type, which is handled elsewhere
+                if (WellKnownHeaders.ContentHeaders.Contains(header.Key, StringComparer.OrdinalIgnoreCase) &&
+                    !string.Equals(WellKnownHeaders.ContentType, header.Key, StringComparison.OrdinalIgnoreCase))
+                {
+                    content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
             }
 
             foreach (KeyValuePair<string, string> header in requestHeaders)
             {
-                content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                // We only want to add content headers, except for Content-Type, which is handled elsewhere
+                if (WellKnownHeaders.ContentHeaders.Contains(header.Key, StringComparer.OrdinalIgnoreCase) &&
+                    !string.Equals(WellKnownHeaders.ContentType, header.Key, StringComparison.OrdinalIgnoreCase))
+                {
+                    content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
             }
         }
 

--- a/src/Microsoft.HttpRepl/Suggestions/HeaderCompletion.cs
+++ b/src/Microsoft.HttpRepl/Suggestions/HeaderCompletion.cs
@@ -9,8 +9,6 @@ namespace Microsoft.HttpRepl.Suggestions
 {
     public class HeaderCompletion
     {
-
-
         /// <summary>
         /// Gets a collection of HTTP header names which starts with the prefix value passed in, except the ones present in existingHeaders.
         /// </summary>

--- a/src/Microsoft.HttpRepl/Suggestions/HeaderCompletion.cs
+++ b/src/Microsoft.HttpRepl/Suggestions/HeaderCompletion.cs
@@ -9,61 +9,7 @@ namespace Microsoft.HttpRepl.Suggestions
 {
     public class HeaderCompletion
     {
-        private static readonly IEnumerable<string> CommonHeaders = new[]
-       {
-            "A-IM",
-            "Accept",
-            "Accept-Charset",
-            "Accept-Encoding",
-            "Accept-Language",
-            "Accept-Datetime",
-            "Access-Control-Request-Method",
-            "Access-Control-Request-Headers",
-            "Authorization",
-            "Cache-Control",
-            "Connection",
-            "Content-Length",
-            "Content-MD5",
-            "Content-Type",
-            "Cookie",
-            "Date",
-            "Expect",
-            "Forwarded",
-            "From",
-            "Host",
-            "If-Match",
-            "If-Modified-Since",
-            "If-None-Match",
-            "If-Range",
-            "If-Unmodified-Since",
-            "Max-Forwards",
-            "Origin",
-            "Pragma",
-            "Proxy-Authentication",
-            "Range",
-            "Referer",
-            "TE",
-            "User-Agent",
-            "Upgrade",
-            "Via",
-            "Warning",
-            //Non-standard
-            "Upgrade-Insecure-Requests",
-            "X-Requested-With",
-            "DNT",
-            "X-Forwarded-For",
-            "X-Forwarded-Host",
-            "X-Forwarded-Proto",
-            "Front-End-Https",
-            "X-Http-Method-Override",
-            "X-ATT-DeviceId",
-            "X-Wap-Profile",
-            "Proxy-Connection",
-            "X-UIDH",
-            "X-Csrf-Token",
-            "X-Request-ID",
-            "X-Correlation-ID"
-        };
+
 
         /// <summary>
         /// Gets a collection of HTTP header names which starts with the prefix value passed in, except the ones present in existingHeaders.
@@ -73,8 +19,8 @@ namespace Microsoft.HttpRepl.Suggestions
         /// <returns></returns>
         public static IEnumerable<string> GetCompletions(IReadOnlyCollection<string> existingHeaders, string prefix)
         {
-            return CommonHeaders.Where(x => x.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
-                                            existingHeaders?.Contains(x) != true);
+            return WellKnownHeaders.CommonHeaders.Where(x => x.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
+                                                             existingHeaders?.Contains(x) != true);
         }
 
         public static IEnumerable<string> GetValueCompletions(string method, string path, string header, string prefix, HttpState programState)

--- a/src/Microsoft.HttpRepl/WellKnownHeaders.cs
+++ b/src/Microsoft.HttpRepl/WellKnownHeaders.cs
@@ -1,17 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
-using Microsoft.HttpRepl.Resources;
 
 namespace Microsoft.HttpRepl
 {
     public static class WellKnownHeaders
     {
+        public static readonly string ContentType = "Content-Type";
+
         public static readonly IEnumerable<string> CommonHeaders = new[]
         {
             "A-IM",
@@ -91,7 +88,5 @@ namespace Microsoft.HttpRepl
 
             "Last-Modified",
         };
-
-        public static readonly string ContentType = "Content-Type";
     }
 }

--- a/src/Microsoft.HttpRepl/WellKnownHeaders.cs
+++ b/src/Microsoft.HttpRepl/WellKnownHeaders.cs
@@ -85,7 +85,6 @@ namespace Microsoft.HttpRepl
             "Content-Range",
             ContentType,
             "Expires",
-
             "Last-Modified",
         };
     }

--- a/src/Microsoft.HttpRepl/WellKnownHeaders.cs
+++ b/src/Microsoft.HttpRepl/WellKnownHeaders.cs
@@ -1,0 +1,97 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Microsoft.HttpRepl.Resources;
+
+namespace Microsoft.HttpRepl
+{
+    public static class WellKnownHeaders
+    {
+        public static readonly IEnumerable<string> CommonHeaders = new[]
+        {
+            "A-IM",
+            "Accept",
+            "Accept-Charset",
+            "Accept-Encoding",
+            "Accept-Language",
+            "Accept-Datetime",
+            "Access-Control-Request-Method",
+            "Access-Control-Request-Headers",
+            "Allow",
+            "Authorization",
+            "Cache-Control",
+            "Connection",
+            "Content-Disposition",
+            "Content-Encoding",
+            "Content-Language",
+            "Content-Length",
+            "Content-Location",
+            "Content-MD5",
+            "Content-Range",
+            ContentType,
+            "Cookie",
+            "Date",
+            "Expect",
+            "Expires",
+            "Forwarded",
+            "From",
+            "Host",
+            "If-Match",
+            "If-Modified-Since",
+            "If-None-Match",
+            "If-Range",
+            "If-Unmodified-Since",
+            "Last-Modified",
+            "Max-Forwards",
+            "Origin",
+            "Pragma",
+            "Proxy-Authentication",
+            "Range",
+            "Referer",
+            "TE",
+            "User-Agent",
+            "Upgrade",
+            "Via",
+            "Warning",
+            //Non-standard
+            "Upgrade-Insecure-Requests",
+            "X-Requested-With",
+            "DNT",
+            "X-Forwarded-For",
+            "X-Forwarded-Host",
+            "X-Forwarded-Proto",
+            "Front-End-Https",
+            "X-Http-Method-Override",
+            "X-ATT-DeviceId",
+            "X-Wap-Profile",
+            "Proxy-Connection",
+            "X-UIDH",
+            "X-Csrf-Token",
+            "X-Request-ID",
+            "X-Correlation-ID"
+        };
+
+        public static readonly IEnumerable<string> ContentHeaders = new []
+        {
+            "Allow",
+            "Content-Disposition",
+            "Content-Encoding",
+            "Content-Language",
+            "Content-Length",
+            "Content-Location",
+            "Content-MD5",
+            "Content-Range",
+            ContentType,
+            "Expires",
+
+            "Last-Modified",
+        };
+
+        public static readonly string ContentType = "Content-Type";
+    }
+}

--- a/test/Microsoft.HttpRepl.Tests/Commands/PostCommandTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/Commands/PostCommandTests.cs
@@ -97,7 +97,6 @@ namespace Microsoft.HttpRepl.Tests.Commands
             PostCommand postCommand = new PostCommand(fileSystem, preferences);
             await postCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
 
-
             List<string> result = shellState.Output;
 
             Assert.Equal(8, result.Count);
@@ -123,7 +122,6 @@ namespace Microsoft.HttpRepl.Tests.Commands
 
             PostCommand postCommand = new PostCommand(fileSystem, preferences);
             await postCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
-
 
             List<string> result = shellState.Output;
 

--- a/test/Microsoft.HttpRepl.Tests/Commands/PostCommandTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/Commands/PostCommandTests.cs
@@ -236,7 +236,5 @@ namespace Microsoft.HttpRepl.Tests.Commands
             Assert.Contains("HTTP/1.1 200 OK", result);
             Assert.Contains(fileContents, result);
         }
-
-
     }
 }


### PR DESCRIPTION
Fixes #237.

There were actually two separate things going on:

1. As pointed out by #237, almost all headers were duplicated if you were doing anything with a request body (because headers were being set for both the request and the content).
2. The fix in #277 showed the other part of it - that Content-Type specifically was always being duplicated (with or without a request body) if it was added with `set header` or the `--header` argument, because it was special-cased and set early before all those were added in bulk.

This PR addresses both issues, and supersedes #277, which I'll close with an explanation once this goes in.