### PR TITLE
Add support for other encodings

### DIFF
--- a/build/PackageVersions.targets
+++ b/build/PackageVersions.targets
@@ -12,6 +12,7 @@
     <PackageReference Update="Swashbuckle.AspNetCore" Version="5.0.0-rc2" PrivateAssets="All" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
     <PackageReference Update="System.Diagnostics.Process" Version="4.3.0" />
+    <Packagereference Update="System.Text.Encoding.CodePages" Version="4.7.1" />
     <PackageReference Update="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
+++ b/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" />
+    <PackageReference Include="System.Text.Encoding.CodePages" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.HttpRepl/Program.cs
+++ b/src/Microsoft.HttpRepl/Program.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.HttpRepl.Commands;
@@ -28,6 +29,7 @@ namespace Microsoft.HttpRepl
         {
             args = args ?? throw new ArgumentNullException(nameof(args));
 
+            RegisterEncodingProviders();
             ComposeDependencies(ref consoleManager, ref preferences, out HttpState state, out Shell shell);
 
             if (Console.IsOutputRedirected && !consoleManager.AllowOutputRedirection)
@@ -136,6 +138,12 @@ namespace Microsoft.HttpRepl
             }
 
             return new HttpClient();
+        }
+
+        private static void RegisterEncodingProviders()
+        {
+            // Adds Windows-1252, among others
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         }
     }
 }


### PR DESCRIPTION
Addresses #238 by adding a reference to the `System.Text.Encoding.CodePages` package and registering the included `CodePagesEncodingProvider` instance. This makes Windows-1252 and other Codepage encodings available for handling responses.