### PR TITLE
Fix issue with extra spaces in commands

### DIFF
--- a/src/Microsoft.Repl/Parsing/CoreParser.cs
+++ b/src/Microsoft.Repl/Parsing/CoreParser.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Repl.Parsing
             commandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
 
             List<string> sections = commandText.Split(' ').ToList();
+            // We can't use StringSplitOptions.RemoveEmptyEntries because it
+            // is more aggressive than we need, so we need to do it ourselves.
+            RemoveEmptyEntries(sections);
             Dictionary<int, int> sectionStartLookup = new Dictionary<int, int>();
             HashSet<int> quotedSections = new HashSet<int>();
             int runningIndex = 0;
@@ -130,6 +133,24 @@ namespace Microsoft.Repl.Parsing
             }
 
             return new CoreParseResult(caretPosition, caretPositionWithinSelectedSection, commandText, sections, selectedSection, sectionStartLookup, quotedSections);
+        }
+
+        private static void RemoveEmptyEntries(List<string> sections)
+        {
+            if (sections.Count < 2)
+            {
+                return;
+            }
+
+            // We want to remove empty spaces from the beginning, and from the middle
+            // but not from the end.
+            for (int index = 0; index < sections.Count - 1; index++)
+            {
+                if (sections[index].Length == 0)
+                {
+                    sections.RemoveAt(index);
+                }
+            }
         }
     }
 }

--- a/test/Microsoft.Repl.Tests/Parsing/CoreParseResultTests.cs
+++ b/test/Microsoft.Repl.Tests/Parsing/CoreParseResultTests.cs
@@ -80,5 +80,20 @@ namespace Microsoft.Repl.Tests.Parsing
 
             Assert.Equal(expectedSelectedSection, result.SelectedSection);
         }
+
+        [Theory]
+        [InlineData("set base  https://localhost", 3)]
+        [InlineData("run  c:\\script.txt", 2)]
+        [InlineData("help  connect", 2)]
+        [InlineData("set base ", 3)]
+        [InlineData("", 1)]
+        [InlineData(" set base https://localhost", 3)]
+        public void Parse_WithDoubleSpace_RemovesEmptySections(string commandText, int expectedSectionCount)
+        {
+            CoreParser parser = new CoreParser();
+            ICoreParseResult parseResult = parser.Parse(commandText, commandText.Length + 1);
+
+            Assert.Equal(expectedSectionCount, parseResult.Sections.Count);
+        }
     }
 }


### PR DESCRIPTION
Fixes #365 

This is a short-term quick fix to try to sneak it into 3.1 while we work on the new parsing in 5.0. Will cherry-pick to release/3.1 once approved.