### PR TITLE
"Handle" special windows keyboard keys

### DIFF
--- a/src/Microsoft.Repl/Input/KeyHandlers.cs
+++ b/src/Microsoft.Repl/Input/KeyHandlers.cs
@@ -81,6 +81,11 @@ namespace Microsoft.Repl.Input
             inputManager.RegisterKeyHandler(ConsoleKey.Select, Unhandled);
             inputManager.RegisterKeyHandler(ConsoleKey.Separator, Unhandled);
             inputManager.RegisterKeyHandler(ConsoleKey.Sleep, Unhandled);
+
+            inputManager.RegisterKeyHandler(ConsoleKey.LeftWindows, Unhandled);
+            inputManager.RegisterKeyHandler(ConsoleKey.RightWindows, Unhandled);
+            inputManager.RegisterKeyHandler(ConsoleKey.Applications, Unhandled);
+
         }
 
         private static Task End(ConsoleKeyInfo keyInfo, IShellState state, CancellationToken cancellationToken)

--- a/src/Microsoft.Repl/Input/KeyHandlers.cs
+++ b/src/Microsoft.Repl/Input/KeyHandlers.cs
@@ -85,7 +85,6 @@ namespace Microsoft.Repl.Input
             inputManager.RegisterKeyHandler(ConsoleKey.LeftWindows, Unhandled);
             inputManager.RegisterKeyHandler(ConsoleKey.RightWindows, Unhandled);
             inputManager.RegisterKeyHandler(ConsoleKey.Applications, Unhandled);
-
         }
 
         private static Task End(ConsoleKeyInfo keyInfo, IShellState state, CancellationToken cancellationToken)

--- a/src/Microsoft.Repl/Microsoft.Repl.csproj
+++ b/src/Microsoft.Repl/Microsoft.Repl.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Description>A framework for creating REPLs in .NET Standard.</Description>
     <PackageTags>dotnet;repl</PackageTags>
     <PackageId>Microsoft.Repl</PackageId>


### PR DESCRIPTION
Fixes #374.

Prior to this fix, pressing the Windows key (or the application key) could cause you to get a null character (`\0`) in the input buffer. Depending on where this landed in the command you pasted (usually at the end), it could break command parsing. So here we just make sure those three keys are "handled" by using the Unhandled delegate.

Those keys were not available on the `ConsoleKey` enum in the original target of netstandard1.3. After discussions with @bradygaster about which targets were reasonable, we went ahead and moved to netstandard2.0 rather than hardcoding the values. 