### PR TITLE
Fixup /swagger root urls

### DIFF
--- a/src/Microsoft.HttpRepl/Preferences/WellKnownPreference.cs
+++ b/src/Microsoft.HttpRepl/Preferences/WellKnownPreference.cs
@@ -177,5 +177,7 @@ namespace Microsoft.HttpRepl.Preferences
         public static string UseDefaultCredentials { get; } = "httpClient.useDefaultCredentials";
 
         public static string HttpClientUserAgent { get; } = "httpClient.userAgent";
+
+        public static string ConnectCommandSkipRootFix => "connectCommand.skipRootFix";
     }
 }

--- a/test/Microsoft.HttpRepl.Tests/Commands/CommandTestsBase.cs
+++ b/test/Microsoft.HttpRepl.Tests/Commands/CommandTestsBase.cs
@@ -59,6 +59,34 @@ namespace Microsoft.HttpRepl.Tests.Commands
                 contentType);
         }
 
+        protected void ArrangeInputsWithOptional(string commandText,
+            string baseAddress,
+            string path,
+            IDictionary<string, string> urlsWithResponse,
+            out MockedShellState shellState,
+            out HttpState httpState,
+            out ICoreParseResult parseResult,
+            ref MockedFileSystem fileSystem,
+            ref IPreferences preferences,
+            string header = "",
+            bool readBodyFromFile = false,
+            string fileContents = "",
+            string contentType = "")
+        {
+            parseResult = CoreParseResultHelper.Create(commandText);
+            shellState = new MockedShellState();
+
+            httpState = GetHttpStateWithOptional(ref fileSystem,
+                ref preferences,                
+                baseAddress,
+                header,
+                path,
+                urlsWithResponse,
+                readBodyFromFile,
+                fileContents,
+                contentType);
+        }
+
         protected static void VerifyErrorMessageWasWrittenToConsoleManagerError(IShellState shellState)
         {
             Mock<IWritable> error = Mock.Get(shellState.ConsoleManager.Error);
@@ -66,8 +94,8 @@ namespace Microsoft.HttpRepl.Tests.Commands
             error.Verify(s => s.WriteLine(It.IsAny<string>()), Times.Once);
         }
 
-        protected static HttpState GetHttpState(out MockedFileSystem fileSystem,
-            out IPreferences preferences,
+        protected static HttpState GetHttpStateWithOptional(ref MockedFileSystem fileSystem,
+            ref IPreferences preferences,
             string baseAddress = "",
             string header = "",
             string path = "",
@@ -80,8 +108,8 @@ namespace Microsoft.HttpRepl.Tests.Commands
             responseMessage.Content = new MockHttpContent(string.Empty);
             MockHttpMessageHandler messageHandler = new MockHttpMessageHandler(urlsWithResponse, header, readFromFile, fileContents, contentType);
             HttpClient httpClient = new HttpClient(messageHandler);
-            fileSystem = new MockedFileSystem();
-            preferences = new NullPreferences();
+            fileSystem ??= new MockedFileSystem();
+            preferences ??= new NullPreferences();
 
             HttpState httpState = new HttpState(fileSystem, preferences, httpClient);
 
@@ -105,6 +133,30 @@ namespace Microsoft.HttpRepl.Tests.Commands
             }
 
             return httpState;
+        }
+
+        protected static HttpState GetHttpState(out MockedFileSystem fileSystem,
+            out IPreferences preferences,
+            string baseAddress = "",
+            string header = "",
+            string path = "",
+            IDictionary<string, string> urlsWithResponse = null,
+            bool readFromFile = false,
+            string fileContents = "",
+            string contentType = "")
+        {
+            fileSystem = new MockedFileSystem();
+            preferences = new NullPreferences();
+
+            return GetHttpStateWithOptional(ref fileSystem,
+                ref preferences,
+                baseAddress,
+                header,
+                path,
+                urlsWithResponse,
+                readFromFile,
+                fileContents,
+                contentType);
         }
 
         protected ICoreParseResult CreateCoreParseResult(string commandText)


### PR DESCRIPTION
As of .NET 5 RC1, the `dotnet new webapi` template now has a default start url of `swagger`. Because the default Swashbuckle-generated OpenAPI description doesn't contain a Servers element, this will put HttpRepl users that launch from VS/VS Code into a pit of failure by having a base address of `https://localhost:{port}/swagger/`, even though the API is, by default, based at the root. The user won't be able to navigate their API at all, because you can't navigate "above" the base address.

Since it is unlikely a user would put their API inside the `/swagger` path, we will special-case this scenario and remove that from the url. We will give the user an escape hatch via the preference if they do put their API under that path.