### PR TITLE
Update to .NET 5 RC1

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-preview.8.20417.9"
+    "dotnet": "5.0.100-rc.1.20452.10"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20459.8"


### PR DESCRIPTION
Updating the .NET SDK used for building to RC1 (5.0.100-rc.1.20452.10). See https://devblogs.microsoft.com/dotnet/announcing-net-5-0-rc-1/ for details on changes.