### PR TITLE
Update .NET 5 to RC2

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-rc.1.20452.10"
+    "dotnet": "5.0.100-rc.2.20479.15"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20506.7"


### PR DESCRIPTION
Updating global.json to target .NET 5 RC2 released today.