### PR TITLE
Move request details from help to verbose list command

### DIFF
--- a/src/Microsoft.HttpRepl/Commands/HelpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/HelpCommand.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.HttpRepl.Preferences;
 using Microsoft.HttpRepl.Resources;
 using Microsoft.HttpRepl.Suggestions;
 using Microsoft.HttpRepl.Telemetry;
@@ -22,11 +21,9 @@ namespace Microsoft.HttpRepl.Commands
     {
         public string Name => "help";
 
-        private readonly IPreferences _preferences;
-
-        public HelpCommand(IPreferences preferences)
+        public HelpCommand()
         {
-            _preferences = preferences;
+            
         }
 
         public bool? CanHandle(IShellState shellState, HttpState programState, ICoreParseResult parseResult)
@@ -94,7 +91,7 @@ namespace Microsoft.HttpRepl.Commands
 
                     if (!anyHelp)
                     {
-                        output.AppendLine("Unable to locate any help information for the specified command");
+                        output.AppendLine(Strings.HelpCommand_Error_UnableToLocateHelpInfo);
                     }
 
                     shellState.ConsoleManager.Write(output.ToString());

--- a/src/Microsoft.HttpRepl/Program.cs
+++ b/src/Microsoft.HttpRepl/Program.cs
@@ -68,7 +68,7 @@ namespace Microsoft.HttpRepl
 
                         shell.ShellState.ConsoleManager.WriteLine();
                         shell.ShellState.ConsoleManager.WriteLine(Resources.Strings.Help_REPLCommands);
-                        new HelpCommand(preferences).CoreGetHelp(shell.ShellState, (ICommandDispatcher<HttpState, ICoreParseResult>)shell.ShellState.CommandDispatcher, state);
+                        new HelpCommand().CoreGetHelp(shell.ShellState, (ICommandDispatcher<HttpState, ICoreParseResult>)shell.ShellState.CommandDispatcher, state);
                         return;
                     }
 
@@ -116,7 +116,7 @@ namespace Microsoft.HttpRepl
             dispatcher.AddCommandWithTelemetry(telemetry, new EchoCommand());
             dispatcher.AddCommandWithTelemetry(telemetry, new ExitCommand());
             dispatcher.AddCommandWithTelemetry(telemetry, new HeadCommand(fileSystem, preferences));
-            dispatcher.AddCommandWithTelemetry(telemetry, new HelpCommand(preferences));
+            dispatcher.AddCommandWithTelemetry(telemetry, new HelpCommand());
             dispatcher.AddCommandWithTelemetry(telemetry, new GetCommand(fileSystem, preferences));
             dispatcher.AddCommandWithTelemetry(telemetry, new ListCommand(preferences));
             dispatcher.AddCommandWithTelemetry(telemetry, new OptionsCommand(fileSystem, preferences));

--- a/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
+++ b/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
@@ -475,6 +475,24 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Accepts:.
+        /// </summary>
+        internal static string ListCommand_Accepts {
+            get {
+                return ResourceManager.GetString("ListCommand_Accepts", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Available methods:.
+        /// </summary>
+        internal static string ListCommand_AvailableMethods {
+            get {
+                return ResourceManager.GetString("ListCommand_AvailableMethods", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No base address has been set, so there is nothing to list. Use the &quot;set base&quot; command to set a base address..
         /// </summary>
         internal static string ListCommand_Error_NoBaseAddress {

--- a/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
+++ b/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
@@ -466,6 +466,15 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to locate any help information for the specified command.
+        /// </summary>
+        internal static string HelpCommand_Error_UnableToLocateHelpInfo {
+            get {
+                return ResourceManager.GetString("HelpCommand_Error_UnableToLocateHelpInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to If {0} is not an absolute URI, {1} must be specified..
         /// </summary>
         internal static string HttpState_Error_NoAbsoluteUriNoBaseAddress {

--- a/src/Microsoft.HttpRepl/Resources/Strings.resx
+++ b/src/Microsoft.HttpRepl/Resources/Strings.resx
@@ -395,6 +395,12 @@ The .NET Core tools collect usage data in order to help us improve your experien
 </value>
     <comment>{0} is the major.minor version of the current build</comment>
   </data>
+  <data name="ListCommand_Accepts" xml:space="preserve">
+    <value>Accepts:</value>
+  </data>
+  <data name="ListCommand_AvailableMethods" xml:space="preserve">
+    <value>Available methods:</value>
+  </data>
   <data name="PrefCommand_Set_VSCode" xml:space="preserve">
     <value>If your default editor is Visual Studio Code, you should set the default command arguments (`{0}`) to include `-w` or `--wait` to ensure proper integration between HttpRepl and Visual Studio Code.</value>
     <comment>{0} indicates the preference name for the default editor arguments</comment>

--- a/src/Microsoft.HttpRepl/Resources/Strings.resx
+++ b/src/Microsoft.HttpRepl/Resources/Strings.resx
@@ -405,4 +405,7 @@ The .NET Core tools collect usage data in order to help us improve your experien
     <value>If your default editor is Visual Studio Code, you should set the default command arguments (`{0}`) to include `-w` or `--wait` to ensure proper integration between HttpRepl and Visual Studio Code.</value>
     <comment>{0} indicates the preference name for the default editor arguments</comment>
   </data>
+  <data name="HelpCommand_Error_UnableToLocateHelpInfo" xml:space="preserve">
+    <value>Unable to locate any help information for the specified command</value>
+  </data>
 </root>

--- a/src/Microsoft.Repl/Commanding/DefaultCommandInput.cs
+++ b/src/Microsoft.Repl/Commanding/DefaultCommandInput.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Repl.Commanding
             CommandOptionSpecification currentOptionSpec = null;
             InputElement selectedElement = null;
 
-            for (int i = spec.CommandName.Count; i < parseResult.Sections.Count; ++i)
+            for (int i = commandNameElements.Count; i < parseResult.Sections.Count; ++i)
             {
                 //If we're not looking at an option name
                 if (!parseResult.Sections[i].StartsWith(spec.OptionPreamble.ToString(), StringComparison.OrdinalIgnoreCase) || parseResult.IsQuotedSection(i))

--- a/test/Microsoft.HttpRepl.Tests/Commands/HelpCommandTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/Commands/HelpCommandTests.cs
@@ -24,11 +24,11 @@ namespace Microsoft.HttpRepl.Tests.Commands
         [InlineData("hep", null)]
         public void CanHandle(string commandText, bool? expected)
         {
-            HttpState httpState = GetHttpState(out _, out IPreferences preferences);
+            HttpState httpState = GetHttpState(out _, out _);
             ICoreParseResult parseResult = CreateCoreParseResult(commandText);
             IShellState shellState = new MockedShellState();
 
-            HelpCommand helpCommand = new HelpCommand(preferences);
+            HelpCommand helpCommand = new HelpCommand();
 
             bool? result = helpCommand.CanHandle(shellState, httpState, parseResult);
 
@@ -41,7 +41,7 @@ namespace Microsoft.HttpRepl.Tests.Commands
         [InlineData("help z")]
         public void Suggest(string commandText, params string[] expectedResults)
         {
-            HttpState httpState = GetHttpState(out MockedFileSystem fileSystem, out IPreferences preferences);
+            HttpState httpState = GetHttpState(out MockedFileSystem fileSystem, out _);
             ICoreParseResult parseResult = CreateCoreParseResult(commandText);
             IConsoleManager consoleManager = new LoggingConsoleManagerDecorator(new NullConsoleManager());
             DefaultCommandDispatcher<HttpState> commandDispatcher = DefaultCommandDispatcher.Create((ss) => { }, httpState);
@@ -50,7 +50,7 @@ namespace Microsoft.HttpRepl.Tests.Commands
             commandDispatcher.AddCommand(new RunCommand(fileSystem));
             IShellState shellState = new ShellState(commandDispatcher, consoleManager: consoleManager);
 
-            HelpCommand helpCommand = new HelpCommand(preferences);
+            HelpCommand helpCommand = new HelpCommand();
 
             IEnumerable<string> result = helpCommand.Suggest(shellState, httpState, parseResult);
 

--- a/test/Microsoft.HttpRepl.Tests/Commands/ListCommandTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/Commands/ListCommandTests.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.HttpRepl.Commands;
 using Microsoft.HttpRepl.Fakes;
 using Microsoft.HttpRepl.OpenApi;
 using Microsoft.HttpRepl.Preferences;
+using Microsoft.Repl.Commanding;
 using Microsoft.Repl.Parsing;
 using Xunit;
 
@@ -150,8 +152,9 @@ namespace Microsoft.HttpRepl.Tests.Commands
         }
 
         [Fact]
-        public void Suggest_WithBlankSecondParameter_NoExceptionAndNullSuggestions()
+        public void Suggest_WithBlankSecondParameter_NoExceptionAndCorrectSuggestions()
         {
+            // Arrange
             ArrangeInputs(commandText: "dir ",
                           baseAddress: "https://localhost/",
                           path: "/",
@@ -164,9 +167,18 @@ namespace Microsoft.HttpRepl.Tests.Commands
 
             ListCommand listCommand = new ListCommand(preferences);
 
-            IEnumerable<string> suggestions = listCommand.Suggest(shellState, httpState, parseResult);
+            // Act
+            List<string> suggestions = listCommand.Suggest(shellState, httpState, parseResult).ToList();
 
-            Assert.Empty(suggestions);
+            // Assert
+            for (int optionIndex = 0; optionIndex < listCommand.InputSpec.Options.Count; optionIndex++)
+            {
+                CommandOptionSpecification option = listCommand.InputSpec.Options[optionIndex];
+                for (int formIndex = 0; formIndex < option.Forms.Count; formIndex++)
+                {
+                    Assert.Contains(option.Forms[formIndex], suggestions, StringComparer.Ordinal);
+                }
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Resolves #70 by moving the form of the help command that gave details about a particular route out of `help` and into a verbose variant of the list command (`ls --verbose` or `dir --verbose`).

Along the way, also resolves #409 since that prevented this from working as well and resolves #410 since that became immediately apparent once #409 was fixed.