### PR TITLE
Warn about command arguments when using VS Code

### DIFF
--- a/src/Microsoft.HttpRepl/Commands/PrefCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/PrefCommand.cs
@@ -276,15 +276,18 @@ namespace Microsoft.HttpRepl.Commands
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                return path.Contains("Code.exe", StringComparison.OrdinalIgnoreCase);
+                return path.Contains("Code.exe", StringComparison.OrdinalIgnoreCase) ||
+                       path.Contains("Code - Insiders.exe", StringComparison.OrdinalIgnoreCase);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return path.Contains("Visual Studio Code.app", StringComparison.Ordinal);
+                return path.Contains("Visual Studio Code.app", StringComparison.Ordinal) ||
+                       path.Contains("Visual Studio Code - Insiders.app", StringComparison.Ordinal);
             }
             else //  Linux
             {
-                return string.Equals(path, "/usr/bin/code", StringComparison.Ordinal);
+                return string.Equals(path, "/usr/bin/code", StringComparison.Ordinal) ||
+                       string.Equals(path, "/usr/bin/code-insiders", StringComparison.Ordinal);
             }
         }
     }

--- a/src/Microsoft.HttpRepl/Commands/PrefCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/PrefCommand.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -177,6 +178,19 @@ namespace Microsoft.HttpRepl.Commands
             {
                 shellState.ConsoleManager.Error.WriteLine(Resources.Strings.PrefCommand_Error_Saving.SetColor(programState.ErrorColor));
             }
+            else
+            {
+                // If we think they're configurating HttpRepl to use Visual Studio Code as their editor, we should
+                // warn them that for best integration, they should also pass the `-w` or `--wait` arguments to
+                // Visual Studio Code.
+                if (string.Equals(prefName, WellKnownPreference.DefaultEditorCommand, StringComparison.Ordinal))
+                {
+                    if (IsVSCode(prefValue))
+                    {
+                        shellState.ConsoleManager.WriteLine(string.Format(Resources.Strings.PrefCommand_Set_VSCode, WellKnownPreference.DefaultEditorArguments).SetColor(programState.WarningColor));
+                    }
+                }
+            }
         }
 
         private void GetSetting(IShellState shellState, HttpState programState, DefaultCommandInput<ICoreParseResult> commandInput)
@@ -256,6 +270,22 @@ namespace Microsoft.HttpRepl.Commands
             }
 
             return null;
+        }
+
+        private static bool IsVSCode(string path)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return path.Contains("Code.exe", StringComparison.OrdinalIgnoreCase);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return path.Contains("Visual Studio Code.app", StringComparison.Ordinal);
+            }
+            else //  Linux
+            {
+                return string.Equals(path, "/usr/bin/code", StringComparison.Ordinal);
+            }
         }
     }
 }

--- a/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
+++ b/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
@@ -610,6 +610,15 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to If your default editor is Visual Studio Code, you should set the default command arguments (`{0}`) to include `-w` or `--wait` to ensure proper integration between HttpRepl and Visual Studio Code..
+        /// </summary>
+        internal static string PrefCommand_Set_VSCode {
+            get {
+                return ResourceManager.GetString("PrefCommand_Set_VSCode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to If specified, {0} must begin with a period and have at least one character after the period..
         /// </summary>
         internal static string RealFileSystem_Error_InvalidExtension {

--- a/src/Microsoft.HttpRepl/Resources/Strings.resx
+++ b/src/Microsoft.HttpRepl/Resources/Strings.resx
@@ -395,4 +395,8 @@ The .NET Core tools collect usage data in order to help us improve your experien
 </value>
     <comment>{0} is the major.minor version of the current build</comment>
   </data>
+  <data name="PrefCommand_Set_VSCode" xml:space="preserve">
+    <value>If your default editor is Visual Studio Code, you should set the default command arguments (`{0}`) to include `-w` or `--wait` to ensure proper integration between HttpRepl and Visual Studio Code.</value>
+    <comment>{0} indicates the preference name for the default editor arguments</comment>
+  </data>
 </root>

--- a/test/Microsoft.HttpRepl.Tests/Commands/PrefCommandTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/Commands/PrefCommandTests.cs
@@ -289,9 +289,12 @@ namespace Microsoft.HttpRepl.Tests.Commands
         public static IEnumerable<object[]> ExecuteAsync_SetDefaultEditorToVSCode_ShowsWarning_Data { get; } = new List<object[]>()
         {
             new object[] { "c:\\users\\username\\appdata\\local\\programs\\Microsoft VS Code\\Code.exe", OSPlatform.Windows },
+            new object[] { "c:\\users\\username\\appdata\\local\\programs\\Microsoft VS Code Insiders\\Code - Insiders.exe", OSPlatform.Windows },
             new object[] { "C:\\Program Files\\Microsoft VS Code\\Code.exe", OSPlatform.Windows },
             new object[] { "/usr/bin/code", OSPlatform.Linux },
+            new object[] { "/usr/bin/code-insiders", OSPlatform.Linux },
             new object[] { "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code", OSPlatform.OSX },
+            new object[] { "/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code-insiders", OSPlatform.OSX },
         };
 
         private static async Task ValidatePreference(string commandText, string preferenceName, Func<HttpState, string> expectedValueCallback)


### PR DESCRIPTION
Resolves #310 

Since, at this point, we don't want to override the user's settings automatically, for now we will just present a warning if we think they are setting their default editor to VS Code. The warning guides them to set the proper command arguments. 