### PR TITLE
Remove unused steps from build process

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,9 +57,8 @@ stages:
   jobs:
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
-      enablePublishUsingPipelines: true
       enablePublishBuildArtifacts: true
-      enablePublishTestResults: true
+      testResultsFormat: xunit
       enableTelemetry: true
       helixRepo: dotnet/HttpRepl
       # enableMicrobuild can't be read from a user-defined variable (Azure DevOps limitation)
@@ -119,15 +118,6 @@ stages:
             artifactName: Packages_$(Agent.Os)_$(Agent.JobName)
             parallel: true
             pathtoPublish: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
-            publishLocation: Container
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Logs
-          condition: always()
-          continueOnError: true
-          inputs:
-            artifactName: Logs_$(Agent.Os)_$(Agent.JobName)
-            parallel: true
-            pathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
             publishLocation: Container
 
       - job: macOS

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -142,15 +142,6 @@ stages:
           name: Build
           displayName: Build
           condition: succeeded()
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Logs
-          condition: always()
-          continueOnError: true
-          inputs:
-            artifactName: Logs_$(Agent.Os)_$(Agent.JobName)
-            parallel: true
-            pathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
-            publishLocation: Container
 
       - job: Linux
         pool:
@@ -175,12 +166,3 @@ stages:
           name: Build
           displayName: Build
           condition: succeeded()
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Logs
-          condition: always()
-          continueOnError: true
-          inputs:
-            artifactName: Logs_$(Agent.Os)_$(Agent.JobName)
-            parallel: true
-            pathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
-            publishLocation: Container


### PR DESCRIPTION
A couple of small build tweaks here:

- Arcade updated their scripts so you can configure it to only publish the xunit test results and not the trx test results. We just need to swap out `enablePublishTestResults: true` (which will publish both) for `testResultsFormat: xunit` (which will only publish xunit results. This will get rid of the build warnings we had (one per platform per configuration)
- The `enablePublishUsingPipelines: true` parameter wasn't needed for what we're doing in our builds
- We were publishing the log files twice under slightly different container names - once in our build steps and then again in the Arcade templates.