### PR TITLE
Update Analyzers to 3.3 and disable var

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -58,9 +58,9 @@ dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion
 
 # Require var all the time.
-csharp_style_var_for_built_in_types = true:suggestion
-csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:suggestion
+csharp_style_var_elsewhere = false:suggestion
 
 # Disallow throw expressions.
 csharp_style_throw_expression = false:suggestion

--- a/build/PackageVersions.targets
+++ b/build/PackageVersions.targets
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Update="Microsoft.ApplicationInsights.WorkerService" Version="2.14.0" />
     <PackageReference Update="Microsoft.AspNet.WebApi.Client" Version="5.2.6" />
-    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4" PrivateAssets="All" />
+    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" PrivateAssets="All" />
     <PackageReference Update="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageReference Update="Microsoft.OpenApi.Readers" Version="1.2.2" />
     <PackageReference Update="Microsoft.Win32.Registry" Version="4.7.0" />

--- a/src/Microsoft.HttpRepl.Telemetry/Telemetry.cs
+++ b/src/Microsoft.HttpRepl.Telemetry/Telemetry.cs
@@ -16,11 +16,11 @@ namespace Microsoft.HttpRepl.Telemetry
     [SuppressMessage("Naming", "CA1724: Type names should not match namespaces", Justification = "Keeping it consistent with source implementations.")]
     public sealed class Telemetry : ITelemetry
     {
-        internal static string CurrentSessionId = null;
-        private TelemetryClient _client = null;
-        private Dictionary<string, string> _commonProperties = null;
-        private Dictionary<string, double> _commonMeasurements = null;
-        private Task _trackEventTask = null;
+        internal static string CurrentSessionId;
+        private TelemetryClient _client;
+        private Dictionary<string, string> _commonProperties;
+        private Dictionary<string, double> _commonMeasurements;
+        private Task _trackEventTask;
 
         private const string InstrumentationKey = "469489a6-628b-4bb9-80db-ec670f70d874";
         public const string TelemetryOptout = "DOTNET_HTTPREPL_TELEMETRY_OPTOUT";

--- a/src/Microsoft.HttpRepl.Telemetry/UserLevelCacheWriter.cs
+++ b/src/Microsoft.HttpRepl.Telemetry/UserLevelCacheWriter.cs
@@ -48,7 +48,7 @@ namespace Microsoft.HttpRepl.Telemetry
 
         public string RunWithCache(string cacheKey, Func<string> getValueToCache)
         {
-            getValueToCache = getValueToCache ?? throw new ArgumentNullException(nameof(getValueToCache));
+            _ = getValueToCache ?? throw new ArgumentNullException(nameof(getValueToCache));
 
             var cacheFilepath = GetCacheFilePath(cacheKey);
             try

--- a/src/Microsoft.HttpRepl.Telemetry/UserLevelCacheWriter.cs
+++ b/src/Microsoft.HttpRepl.Telemetry/UserLevelCacheWriter.cs
@@ -48,6 +48,8 @@ namespace Microsoft.HttpRepl.Telemetry
 
         public string RunWithCache(string cacheKey, Func<string> getValueToCache)
         {
+            getValueToCache = getValueToCache ?? throw new ArgumentNullException(nameof(getValueToCache));
+
             var cacheFilepath = GetCacheFilePath(cacheKey);
             try
             {

--- a/src/Microsoft.HttpRepl/ApiConnection.cs
+++ b/src/Microsoft.HttpRepl/ApiConnection.cs
@@ -74,7 +74,7 @@ namespace Microsoft.HttpRepl
                 {
                     if (Uri.TryCreate(baseUriToCheck, swaggerSearchPath, out Uri? swaggerUri) && !checkedUris.Contains(swaggerUri))
                     {
-                        var document = await GetSwaggerDocAsync(client, swaggerUri, cancellationToken);
+                        string? document = await GetSwaggerDocAsync(client, swaggerUri, cancellationToken);
                         if (document is not null)
                         {
                             SwaggerUri = swaggerUri;
@@ -92,7 +92,7 @@ namespace Microsoft.HttpRepl
             try
             {
                 WriteVerbose(string.Format(Resources.Strings.ApiConnection_Logging_Checking, uri));
-                var response = await client.GetAsync(uri, cancellationToken).ConfigureAwait(false);
+                HttpResponseMessage? response = await client.GetAsync(uri, cancellationToken).ConfigureAwait(false);
                 if (cancellationToken.IsCancellationRequested)
                 {
                     _logger.WriteLine(Resources.Strings.ApiConnection_Logging_Cancelled);
@@ -102,7 +102,12 @@ namespace Microsoft.HttpRepl
                 if (response.IsSuccessStatusCode)
                 {
                     WriteLineVerbose(Resources.Strings.ApiConnection_Logging_Found);
+
+#if NET5_0
+                    string responseString = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
                     string responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
 
                     WriteVerbose(Resources.Strings.ApiConnection_Logging_Parsing);
                     ApiDefinitionReader reader = new ApiDefinitionReader();

--- a/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
@@ -158,9 +158,9 @@ namespace Microsoft.HttpRepl.Commands
                     }
                 }
 
-                var responseFileOption = commandInput.Options[ResponseFileOption].Any() ? commandInput.Options[ResponseFileOption][0] : null;
-                var responseHeadersFileOption = commandInput.Options[ResponseHeadersFileOption].Any() ? commandInput.Options[ResponseHeadersFileOption][0] : null;
-                var responseBodyFileOption = commandInput.Options[ResponseBodyFileOption].Any() ? commandInput.Options[ResponseBodyFileOption][0] : null;
+                InputElement responseFileOption = commandInput.Options[ResponseFileOption].Any() ? commandInput.Options[ResponseFileOption][0] : null;
+                InputElement responseHeadersFileOption = commandInput.Options[ResponseHeadersFileOption].Any() ? commandInput.Options[ResponseHeadersFileOption][0] : null;
+                InputElement responseBodyFileOption = commandInput.Options[ResponseBodyFileOption].Any() ? commandInput.Options[ResponseBodyFileOption][0] : null;
 
                 string headersTarget = responseHeadersFileOption?.Text ?? responseFileOption?.Text;
                 string bodyTarget = responseBodyFileOption?.Text ?? responseFileOption?.Text;
@@ -298,7 +298,7 @@ namespace Microsoft.HttpRepl.Commands
             return ".tmp";
         }
 
-        private void AddHttpContentHeaders(HttpContent content, HttpState programState, Dictionary<string, string> requestHeaders)
+        private static void AddHttpContentHeaders(HttpContent content, HttpState programState, Dictionary<string, string> requestHeaders)
         {
             foreach (KeyValuePair<string, IEnumerable<string>> header in programState.Headers)
             {
@@ -448,7 +448,13 @@ namespace Microsoft.HttpRepl.Commands
             if (commandInput.Options[StreamingOption].Count > 0)
             {
                 Memory<char> buffer = new Memory<char>(new char[2048]);
+
+#if NET5_0
+                Stream s = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#else
                 Stream s = await content.ReadAsStreamAsync().ConfigureAwait(false);
+#endif
+
                 using (StreamReader reader = new StreamReader(s))
                 {
                     consoleManager.WriteLine(Resources.Strings.BaseHttpCommand_FormatBodyAsync_Streaming.SetColor(programState.WarningColor));
@@ -587,7 +593,7 @@ namespace Microsoft.HttpRepl.Commands
 
         protected override string GetHelpDetails(IShellState shellState, HttpState programState, DefaultCommandInput<ICoreParseResult> commandInput, ICoreParseResult parseResult)
         {
-            var helpText = new StringBuilder();
+            StringBuilder helpText = new StringBuilder();
             helpText.Append(Resources.Strings.Usage.Bold());
             helpText.AppendLine($"{Verb.ToUpperInvariant()} [Options]");
             helpText.AppendLine();
@@ -727,7 +733,7 @@ namespace Microsoft.HttpRepl.Commands
             return null;
         }
 
-        private string GetExampleBody(string path, ref string contentType, string method, HttpState httpState)
+        private static string GetExampleBody(string path, ref string contentType, string method, HttpState httpState)
         {
             Uri effectivePath = httpState.GetEffectivePath(path);
             string rootRelativePath = effectivePath.LocalPath.Substring(httpState.BaseAddress.LocalPath.Length).TrimStart('/');

--- a/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
@@ -463,7 +463,9 @@ namespace Microsoft.HttpRepl.Commands
                     {
                         try
                         {
+#pragma warning disable CA2012 // Use ValueTasks correctly
                             ValueTask<int> readTask = reader.ReadAsync(buffer, cancellationToken);
+#pragma warning restore CA2012 // Use ValueTasks correctly
                             if (await WaitForCompletionAsync(readTask, cancellationToken).ConfigureAwait(false))
                             {
                                 if (readTask.Result == 0)

--- a/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
@@ -463,9 +463,7 @@ namespace Microsoft.HttpRepl.Commands
                     {
                         try
                         {
-#pragma warning disable CA2012 // Use ValueTasks correctly
-                            ValueTask<int> readTask = reader.ReadAsync(buffer, cancellationToken);
-#pragma warning restore CA2012 // Use ValueTasks correctly
+                            Task<int> readTask = reader.ReadAsync(buffer, cancellationToken).AsTask();
                             if (await WaitForCompletionAsync(readTask, cancellationToken).ConfigureAwait(false))
                             {
                                 if (readTask.Result == 0)
@@ -541,7 +539,7 @@ namespace Microsoft.HttpRepl.Commands
             consoleManager.WriteLine(responseContent);
         }
 
-        private static async Task<bool> WaitForCompletionAsync(ValueTask<int> readTask, CancellationToken cancellationToken)
+        private static async Task<bool> WaitForCompletionAsync(Task<int> readTask, CancellationToken cancellationToken)
         {
             while (!readTask.IsCompleted && !cancellationToken.IsCancellationRequested && !Console.KeyAvailable)
             {

--- a/src/Microsoft.HttpRepl/Commands/ClearCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ClearCommand.cs
@@ -13,7 +13,7 @@ namespace Microsoft.HttpRepl.Commands
 {
     public class ClearCommand : ICommand<object, ICoreParseResult>
     {
-        private static readonly string AlternateName = "cls";
+        private const string AlternateName = "cls";
 
         public string Name => "clear";
 

--- a/src/Microsoft.HttpRepl/Commands/ConnectCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ConnectCommand.cs
@@ -64,7 +64,7 @@ namespace Microsoft.HttpRepl.Commands
         {
             if (parseResult.ContainsAtLeast(Name))
             {
-                var helpText = new StringBuilder();
+                StringBuilder helpText = new StringBuilder();
                 helpText.Append(Resources.Strings.Usage.Bold());
                 helpText.AppendLine("connect [rootAddress] [--base baseAddress] [--openapi openApiDescriptionAddress] [--verbose]");
                 helpText.AppendLine();
@@ -91,7 +91,7 @@ namespace Microsoft.HttpRepl.Commands
             string swaggerAddress = GetSwaggerAddressFromCommand(commandInput);
             bool isVerbosityEnabled = GetOptionExistsFromCommand(commandInput, VerbosityOption);
 
-            ApiConnection connectionInfo = GetConnectionInfo(shellState, programState, rootAddress, baseAddress, swaggerAddress, _preferences, isVerbosityEnabled);
+            ApiConnection connectionInfo = GetConnectionInfo(shellState, rootAddress, baseAddress, swaggerAddress, _preferences, isVerbosityEnabled);
 
             bool rootSpecified = !string.IsNullOrWhiteSpace(rootAddress);
             bool baseSpecified = !string.IsNullOrWhiteSpace(baseAddress);
@@ -137,7 +137,7 @@ namespace Microsoft.HttpRepl.Commands
             shellState.ConsoleManager.WriteLine(Resources.Strings.HelpCommand_Core_Details_Line2.Bold().Cyan());
         }
 
-        private ApiConnection GetConnectionInfo(IShellState shellState, HttpState programState, string rootAddress, string baseAddress, string swaggerAddress, IPreferences preferences, bool isVerbosityEnabled)
+        private ApiConnection GetConnectionInfo(IShellState shellState, string rootAddress, string baseAddress, string swaggerAddress, IPreferences preferences, bool isVerbosityEnabled)
         {
             rootAddress = rootAddress?.Trim();
             baseAddress = baseAddress?.Trim();

--- a/src/Microsoft.HttpRepl/Commands/HelpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/HelpCommand.cs
@@ -50,7 +50,7 @@ namespace Microsoft.HttpRepl.Commands
                 else
                 {
                     bool anyHelp = false;
-                    var output = new StringBuilder();
+                    StringBuilder output = new StringBuilder();
 
                     if (parseResult.Slice(1) is ICoreParseResult continuationParseResult)
                     {
@@ -64,15 +64,15 @@ namespace Microsoft.HttpRepl.Commands
                                 output.AppendLine();
                                 output.AppendLine(help);
 
-                                var structuredCommand = GetStructuredCommand(command);
+                                CommandWithStructuredInputBase<HttpState, ICoreParseResult> structuredCommand = GetStructuredCommand(command);
                                 if (structuredCommand is not null && structuredCommand.InputSpec.Options.Any())
                                 {
                                     output.AppendLine();
                                     output.AppendLine(Strings.Options.Bold());
-                                    foreach (var option in structuredCommand.InputSpec.Options)
+                                    foreach (CommandOptionSpecification option in structuredCommand.InputSpec.Options)
                                     {
-                                        var optionText = string.Empty;
-                                        foreach (var form in option.Forms)
+                                        string optionText = string.Empty;
+                                        foreach (string form in option.Forms)
                                         {
                                             if (!string.IsNullOrEmpty(optionText))
                                             {
@@ -171,14 +171,14 @@ namespace Microsoft.HttpRepl.Commands
             return null;
         }
 
-        public void CoreGetHelp(IShellState shellState, ICommandDispatcher<HttpState, ICoreParseResult> dispatcher, HttpState programState)
+        public static void CoreGetHelp(IShellState shellState, ICommandDispatcher<HttpState, ICoreParseResult> dispatcher, HttpState programState)
         {
             shellState = shellState ?? throw new ArgumentNullException(nameof(shellState));
 
             dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
 
             const int navCommandColumn = -15;
-            var output = new StringBuilder();
+            StringBuilder output = new StringBuilder();
 
             output.AppendLine();
             output.AppendLine(Strings.HelpCommand_Core_SetupCommands.Bold().Cyan());
@@ -232,7 +232,7 @@ namespace Microsoft.HttpRepl.Commands
             shellState.ConsoleManager.Write(output.ToString());
         }
 
-        private CommandWithStructuredInputBase<HttpState, ICoreParseResult> GetStructuredCommand(ICommand<HttpState, ICoreParseResult> rawCommand)
+        private static CommandWithStructuredInputBase<HttpState, ICoreParseResult> GetStructuredCommand(ICommand<HttpState, ICoreParseResult> rawCommand)
         {
             return rawCommand switch
             {

--- a/src/Microsoft.HttpRepl/Commands/RunCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/RunCommand.cs
@@ -21,7 +21,7 @@ namespace Microsoft.HttpRepl.Commands
     {
         public string Name => "run";
 
-        private IFileSystem _fileSystem;
+        private readonly IFileSystem _fileSystem;
         public RunCommand(IFileSystem fileSystem)
         {
             _fileSystem = fileSystem;
@@ -44,7 +44,7 @@ namespace Microsoft.HttpRepl.Commands
 
             if (!_fileSystem.FileExists(parseResult.Sections[1]))
             {
-                shellState.ConsoleManager.Error.WriteLine(String.Format(Strings.RunCommand_CouldNotFindScriptFile, parseResult.Sections[1]));
+                shellState.ConsoleManager.Error.WriteLine(string.Format(Strings.RunCommand_CouldNotFindScriptFile, parseResult.Sections[1]));
                 return;
             }
 
@@ -63,7 +63,7 @@ namespace Microsoft.HttpRepl.Commands
         {
             if (parseResult.ContainsAtLeast(Name))
             {
-                var helpText = new StringBuilder();
+                StringBuilder helpText = new StringBuilder();
                 helpText.Append(Strings.Usage.Bold());
                 helpText.AppendLine(Strings.RunCommand_HelpDetails);
                 return helpText.ToString();

--- a/src/Microsoft.HttpRepl/Commands/SetHeaderCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/SetHeaderCommand.cs
@@ -20,13 +20,13 @@ namespace Microsoft.HttpRepl.Commands
 {
     public class SetHeaderCommand : ICommand<HttpState, ICoreParseResult>
     {
-        private static readonly string CommandName = "set";
-        private static readonly string SubCommand = "header";
+        private const string CommandName = "set";
+        private const string SubCommand = "header";
 
         private readonly ITelemetry _telemetry;
 
         public string Name => "setHeader";
-        public string Description => Strings.SetHeaderCommand_HelpSummary;
+        public static string Description => Strings.SetHeaderCommand_HelpSummary;
 
         public SetHeaderCommand(ITelemetry telemetry)
         {
@@ -67,7 +67,7 @@ namespace Microsoft.HttpRepl.Commands
         {
             if (parseResult.ContainsAtLeast(CommandName, SubCommand))
             {
-                var helpText = new StringBuilder();
+                StringBuilder helpText = new StringBuilder();
                 helpText.Append(Strings.Usage.Bold());
                 helpText.AppendLine("set header {name} [value]");
                 helpText.AppendLine();

--- a/src/Microsoft.HttpRepl/Commands/UICommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/UICommand.cs
@@ -18,8 +18,8 @@ namespace Microsoft.HttpRepl.Commands
     public class UICommand : ICommand<HttpState, ICoreParseResult>
     {
         public string Name => "ui";
-        private IUriLauncher _uriLauncher;
-        private IPreferences _preferences;
+        private readonly IUriLauncher _uriLauncher;
+        private readonly IPreferences _preferences;
 
         public UICommand(IUriLauncher uriLauncher, IPreferences preferences)
         {
@@ -98,7 +98,7 @@ namespace Microsoft.HttpRepl.Commands
                 {
                     string parameter = "{swaggerUIAddress}";
                     string defaultAddress = "[BaseAddress]/swagger";
-                    var helpText = new StringBuilder();
+                    StringBuilder helpText = new StringBuilder();
                     helpText.Append(Strings.Usage.Bold());
                     helpText.AppendLine("ui [{swaggerUIAddress}]");
                     helpText.AppendLine();

--- a/src/Microsoft.HttpRepl/FileSystem/RealFileSystem.cs
+++ b/src/Microsoft.HttpRepl/FileSystem/RealFileSystem.cs
@@ -63,7 +63,7 @@ namespace Microsoft.HttpRepl.FileSystem
             return "HttpRepl." + Guid.NewGuid().ToString() + fileExtension;
         }
 
-        private void VerifyDirectoryExists(string path)
+        private static void VerifyDirectoryExists(string path)
         {
             Directory.CreateDirectory(Path.GetDirectoryName(path));   
         }

--- a/src/Microsoft.HttpRepl/HttpState.cs
+++ b/src/Microsoft.HttpRepl/HttpState.cs
@@ -8,14 +8,12 @@ using System.Net.Http;
 using Microsoft.HttpRepl.FileSystem;
 using Microsoft.HttpRepl.OpenApi;
 using Microsoft.HttpRepl.Preferences;
-using Microsoft.HttpRepl.Telemetry;
 using Microsoft.Repl.ConsoleHandling;
 
 namespace Microsoft.HttpRepl
 {
     public class HttpState
     {
-        private readonly IFileSystem _fileSystem;
         private readonly IPreferences _preferences;
 
         public HttpClient Client { get; }
@@ -30,8 +28,6 @@ namespace Microsoft.HttpRepl
 
         public Uri BaseAddress { get; set; }
 
-        private Uri ApiDefinitionBaseAddress => ApiDefinition?.BaseAddresses?.FirstOrDefault().Url;
-
         public IDirectoryStructure Structure => ApiDefinition?.DirectoryStructure;
 
         public bool EchoRequest { get; set; }
@@ -40,11 +36,10 @@ namespace Microsoft.HttpRepl
 
         public Uri SwaggerEndpoint { get; set; }
 
-        public HttpState(IFileSystem fileSystem, IPreferences preferences, HttpClient httpClient)
+        public HttpState(IPreferences preferences, HttpClient httpClient)
         {
             preferences = preferences ?? throw new ArgumentNullException(nameof(preferences));
 
-            _fileSystem = fileSystem;
             _preferences = preferences;
             Client = httpClient;
             PathSections = new Stack<string>();

--- a/src/Microsoft.HttpRepl/Preferences/UserFolderPreferences.cs
+++ b/src/Microsoft.HttpRepl/Preferences/UserFolderPreferences.cs
@@ -131,7 +131,7 @@ namespace Microsoft.HttpRepl.Preferences
 
         private Dictionary<string, string> ReadPreferences(IReadOnlyDictionary<string, string> defaultPreferences)
         {
-            var preferences = new Dictionary<string, string>(defaultPreferences);
+            Dictionary<string, string> preferences = new Dictionary<string, string>(defaultPreferences);
 
             if (_fileSystem.FileExists(PreferencesFilePath))
             {
@@ -178,13 +178,13 @@ namespace Microsoft.HttpRepl.Preferences
             }
         }
 
-        private IReadOnlyDictionary<string, string> SetupDefaults(IDictionary<string, string> defaults)
+        private static IReadOnlyDictionary<string, string> SetupDefaults(IDictionary<string, string> defaults)
         {
             Dictionary<string, string> tempDictionary = new Dictionary<string, string>();
 
             if (defaults != null)
             {
-                foreach (var kvp in defaults)
+                foreach (KeyValuePair<string, string> kvp in defaults)
                 {
                     tempDictionary.Add(kvp.Key, kvp.Value);
                 }

--- a/src/Microsoft.HttpRepl/Suggestions/HeaderCompletion.cs
+++ b/src/Microsoft.HttpRepl/Suggestions/HeaderCompletion.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Microsoft.HttpRepl.Suggestions
 {
-    public class HeaderCompletion
+    public static class HeaderCompletion
     {
         /// <summary>
         /// Gets a collection of HTTP header names which starts with the prefix value passed in, except the ones present in existingHeaders.

--- a/src/Microsoft.Repl/ConsoleHandling/AnsiColorExtensions.cs
+++ b/src/Microsoft.Repl/ConsoleHandling/AnsiColorExtensions.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Repl.ConsoleHandling
     {
         // For reference on these codes and values, see:
         // https://en.wikipedia.org/wiki/ANSI_escape_code#Escape_sequences
-        private static readonly string _ansiControlSequenceIntroducer = "\x1B[";
-        private static readonly string _ansiSgrCode = "m";
+        private const string _ansiControlSequenceIntroducer = "\x1B[";
+        private const string _ansiSgrCode = "m";
         private static readonly string _ansiSgrDefaultForegroundColor = $"{_ansiControlSequenceIntroducer}39{_ansiSgrCode}";
         private static readonly string _ansiSgrBold = $"{_ansiControlSequenceIntroducer}1{_ansiSgrCode}";
 
@@ -67,7 +67,7 @@ namespace Microsoft.Repl.ConsoleHandling
             if (color.HasFlag(AllowedColors.Bold))
             {
                 textToColor = textToColor.Bold();
-                color = color & ~AllowedColors.Bold;
+                color &= ~AllowedColors.Bold;
             }
 
             switch (color)

--- a/src/Microsoft.Repl/ConsoleHandling/ConsoleManager.cs
+++ b/src/Microsoft.Repl/ConsoleHandling/ConsoleManager.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Repl.ConsoleHandling
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return default(ConsoleKeyInfo);
+                return default;
             }
             else
             {

--- a/src/Microsoft.Repl/ConsoleHandling/Reporter.cs
+++ b/src/Microsoft.Repl/ConsoleHandling/Reporter.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Repl.ConsoleHandling
 
         private static bool IsVerbose => bool.TryParse(Environment.GetEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE") ?? "false", out bool value) && value;
 
-        private bool ShouldPassAnsiCodesThrough => bool.TryParse(Environment.GetEnvironmentVariable("DOTNET_CLI_CONTEXT_ANSI_PASS_THRU") ?? "false", out bool value) && value;
+        private static bool ShouldPassAnsiCodesThrough => bool.TryParse(Environment.GetEnvironmentVariable("DOTNET_CLI_CONTEXT_ANSI_PASS_THRU") ?? "false", out bool value) && value;
 
         private bool _isCaretVisible = true;
 

--- a/src/Microsoft.Repl/Input/InputManager.cs
+++ b/src/Microsoft.Repl/Input/InputManager.cs
@@ -37,11 +37,11 @@ namespace Microsoft.Repl.Input
 
             if (handler == null)
             {
-                handlers.Remove(default(ConsoleModifiers));
+                handlers.Remove(default);
             }
             else
             {
-                handlers[default(ConsoleModifiers)] = handler;
+                handlers[default] = handler;
             }
 
             return this;
@@ -200,6 +200,8 @@ namespace Microsoft.Repl.Input
 
         public async Task StartAsync(IShellState state, CancellationToken cancellationToken)
         {
+            state = state ?? throw new ArgumentNullException(nameof(state));
+
             StashEchoState();
 
             try

--- a/src/Microsoft.Repl/Input/InputManager.cs
+++ b/src/Microsoft.Repl/Input/InputManager.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Repl.Input
 
         public async Task StartAsync(IShellState state, CancellationToken cancellationToken)
         {
-            state = state ?? throw new ArgumentNullException(nameof(state));
+            _ = state ?? throw new ArgumentNullException(nameof(state));
 
             StashEchoState();
 

--- a/test/Microsoft.HttpRepl.Tests/Commands/ChangeDirectoryCommandTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/Commands/ChangeDirectoryCommandTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.HttpRepl.Tests.Commands
             parseResult = CoreParseResultHelper.Create(commandText);
             HttpClient httpClient = new HttpClient();
 
-            httpState = new HttpState(fileSystem, preferences, httpClient);
+            httpState = new HttpState(preferences, httpClient);
         }
     }
 }

--- a/test/Microsoft.HttpRepl.Tests/Commands/CommandTestsBase.cs
+++ b/test/Microsoft.HttpRepl.Tests/Commands/CommandTestsBase.cs
@@ -111,7 +111,7 @@ namespace Microsoft.HttpRepl.Tests.Commands
             fileSystem ??= new MockedFileSystem();
             preferences ??= new NullPreferences();
 
-            HttpState httpState = new HttpState(fileSystem, preferences, httpClient);
+            HttpState httpState = new HttpState(preferences, httpClient);
 
             if (!string.IsNullOrWhiteSpace(baseAddress))
             {

--- a/test/Microsoft.HttpRepl.Tests/Commands/PostCommandTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/Commands/PostCommandTests.cs
@@ -298,7 +298,7 @@ namespace Microsoft.HttpRepl.Tests.Commands
             IPreferences preferences = new UserFolderPreferences(fileSystem, userProfileDirectoryProvider, null);
             ICoreParseResult parseResult = CoreParseResultHelper.Create(commandText);
             HttpClient httpClient = new HttpClient();
-            HttpState httpState = new HttpState(fileSystem, preferences, httpClient);
+            HttpState httpState = new HttpState(preferences, httpClient);
             PostCommand postCommand = new PostCommand(fileSystem, preferences);
 
             preferences.SetValue(WellKnownPreference.DefaultEditorCommand, editorPath);

--- a/test/Microsoft.HttpRepl.Tests/Commands/PrefCommandTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/Commands/PrefCommandTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.HttpRepl.Tests.Commands
             IUserProfileDirectoryProvider userProfileDirectoryProvider = new UserProfileDirectoryProvider();
             UserFolderPreferences preferences = new UserFolderPreferences(fileSystem, userProfileDirectoryProvider, TestDefaultPreferences.GetDefaultPreferences());
             HttpClient httpClient = new HttpClient();
-            HttpState httpState = new HttpState(fileSystem, preferences, httpClient);
+            HttpState httpState = new HttpState(preferences, httpClient);
             MockedShellState shellState = new MockedShellState();
             PrefCommand command = new PrefCommand(preferences, new NullTelemetry());
 
@@ -323,7 +323,7 @@ namespace Microsoft.HttpRepl.Tests.Commands
             IUserProfileDirectoryProvider userProfileDirectoryProvider = new UserProfileDirectoryProvider();
             preferences = new UserFolderPreferences(fileSystem, userProfileDirectoryProvider, TestDefaultPreferences.GetDefaultPreferences());
             HttpClient httpClient = new HttpClient();
-            httpState = new HttpState(fileSystem, preferences, httpClient);
+            httpState = new HttpState(preferences, httpClient);
             shellState = new MockedShellState();
             parseResult = CoreParseResultHelper.Create(commandText);
             command = new PrefCommand(preferences, new NullTelemetry());

--- a/test/Microsoft.HttpRepl.Tests/Commands/SetHeaderCommandTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/Commands/SetHeaderCommandTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.HttpRepl.Tests.Commands
             SetHeaderCommand setHeaderCommand = new SetHeaderCommand(new NullTelemetry());
             string result = setHeaderCommand.GetHelpSummary(shellState, httpState);
 
-            Assert.Equal(setHeaderCommand.Description, result);
+            Assert.Equal(SetHeaderCommand.Description, result);
         }
 
         [Fact]

--- a/test/Microsoft.HttpRepl.Tests/Commands/UICommandTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/Commands/UICommandTests.cs
@@ -290,7 +290,7 @@ namespace Microsoft.HttpRepl.Tests.Commands
             MockedFileSystem fileSystem = new MockedFileSystem();
             UserFolderPreferences preferences = new UserFolderPreferences(fileSystem, new UserProfileDirectoryProvider(), null);
             preferences.SetValue(WellKnownPreference.SwaggerUIEndpoint, "/mySwaggerPath");
-            HttpState httpState = new HttpState(fileSystem, preferences, new HttpClient());
+            HttpState httpState = new HttpState(preferences, new HttpClient());
             httpState.BaseAddress = new Uri("https://localhost:44366", UriKind.Absolute);
 
             Mock<IUriLauncher> mockLauncher = new Mock<IUriLauncher>();
@@ -313,7 +313,7 @@ namespace Microsoft.HttpRepl.Tests.Commands
             MockedFileSystem fileSystem = new MockedFileSystem();
             UserFolderPreferences preferences = new UserFolderPreferences(fileSystem, new UserProfileDirectoryProvider(), null);
             preferences.SetValue(WellKnownPreference.SwaggerUIEndpoint, "https://localhost:12345/mySwaggerPath");
-            HttpState httpState = new HttpState(fileSystem, preferences, new HttpClient());
+            HttpState httpState = new HttpState(preferences, new HttpClient());
             httpState.BaseAddress = new Uri("https://localhost:44366", UriKind.Absolute);
 
             Mock<IUriLauncher> mockLauncher = new Mock<IUriLauncher>();

--- a/test/Microsoft.HttpRepl.Tests/HttpStateTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/HttpStateTests.cs
@@ -232,7 +232,7 @@ namespace Microsoft.HttpRepl.Tests
             }
             
             HttpClient client = new HttpClient();
-            HttpState state = new HttpState(fileSystem, preferences, client);
+            HttpState state = new HttpState(preferences, client);
 
             return state;
         }

--- a/test/Microsoft.HttpRepl.Tests/Suggestions/HeaderCompletionTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/Suggestions/HeaderCompletionTests.cs
@@ -203,7 +203,7 @@ namespace Microsoft.HttpRepl.Tests.Suggestions
             IPreferences preferences = new UserFolderPreferences(fileSystem, userProfileDirectoryProvider, null);
             HttpClient httpClient = new HttpClient();
 
-            return new HttpState(fileSystem, preferences, httpClient);
+            return new HttpState(preferences, httpClient);
         }
     }
 }

--- a/test/Microsoft.HttpRepl.Tests/Suggestions/ServerPathCompletionTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/Suggestions/ServerPathCompletionTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.HttpRepl.Tests.Suggestions
             IPreferences preferences = new UserFolderPreferences(fileSystem, userProfileDirectoryProvider, null);
             HttpClient httpClient = new HttpClient();
 
-            HttpState httpState = new HttpState(fileSystem, preferences, httpClient);
+            HttpState httpState = new HttpState(preferences, httpClient);
 
             DirectoryStructure structure = new DirectoryStructure(null);
             DirectoryStructure child1 = structure.DeclareDirectory("child1");


### PR DESCRIPTION
Resolves #413, fixes a bunch of warnings/suggestions (I mostly skipped the test and telemetry projects for now) and also switches the .editorconfig var setting to suggest the explicit type name rather than suggesting var.

Added #418 to track one error that I wasn't positive about how to fix at the moment, but didn't want to block the rest of this.