### PR TITLE
Handle HTTP Request errors in BaseHttpCommand

### DIFF
--- a/src/Microsoft.Repl/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Repl/Resources/Strings.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace Microsoft.Repl.Resources {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -40,7 +39,7 @@ namespace Microsoft.Repl.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Repl.Resources.Strings", typeof(Strings).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Repl.Resources.Strings", typeof(Strings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -62,7 +61,7 @@ namespace Microsoft.Repl.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Execution was cancelled.
+        ///   Looks up a localized string similar to Command execution cancelled.
         /// </summary>
         internal static string DefaultCommandDispatcher_Error_ExecutionWasCancelled {
             get {

--- a/src/Microsoft.Repl/Resources/Strings.resx
+++ b/src/Microsoft.Repl/Resources/Strings.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DefaultCommandDispatcher_Error_ExecutionWasCancelled" xml:space="preserve">
-    <value>Execution was cancelled</value>
+    <value>Command execution cancelled</value>
   </data>
   <data name="DefaultCommandDispatcher_Error_NoMatchingCommand" xml:space="preserve">
     <value>No matching command found</value>


### PR DESCRIPTION
Resolves #304.

Handle some of the "expected" exceptions in `BaseHttpCommand` when executing HTTP Requests via `HttpClient`.