### PR TITLE
Add more preferences for configuring openapi search paths

### DIFF
--- a/src/Microsoft.HttpRepl/ApiConnection.cs
+++ b/src/Microsoft.HttpRepl/ApiConnection.cs
@@ -33,7 +33,6 @@ namespace Microsoft.HttpRepl
 
         public ApiConnection(IPreferences preferences, IWritable logger, bool logVerboseMessages, IOpenApiSearchPathsProvider? openApiSearchPaths = null)
         {
-            _ = preferences ?? throw new ArgumentNullException(nameof(preferences));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _logVerboseMessages = logVerboseMessages;
             _searchPaths = openApiSearchPaths ?? new OpenApiSearchPathsProvider(preferences);

--- a/src/Microsoft.HttpRepl/OpenApi/IOpenApiSearchPathsProvider.cs
+++ b/src/Microsoft.HttpRepl/OpenApi/IOpenApiSearchPathsProvider.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+
+namespace Microsoft.HttpRepl.OpenApi
+{
+    internal interface IOpenApiSearchPathsProvider
+    {
+        IEnumerable<string> GetOpenApiSearchPaths();
+    }
+}

--- a/src/Microsoft.HttpRepl/Preferences/OpenApiSearchPathsProvider.cs
+++ b/src/Microsoft.HttpRepl/Preferences/OpenApiSearchPathsProvider.cs
@@ -10,7 +10,7 @@ using Microsoft.HttpRepl.OpenApi;
 
 namespace Microsoft.HttpRepl.Preferences
 {
-    internal class OpenApiSearchPathsProvider : IOpenApiSearchPathsProvider
+    internal sealed class OpenApiSearchPathsProvider : IOpenApiSearchPathsProvider
     {
         // OpenAPI description search paths are appended to the base url to
         // attempt to find the description document. A search path is a
@@ -32,7 +32,7 @@ namespace Microsoft.HttpRepl.Preferences
         private readonly IPreferences _preferences;
         public OpenApiSearchPathsProvider(IPreferences preferences)
         {
-            _preferences = preferences;
+            _preferences = preferences ?? throw new ArgumentNullException(nameof(preferences));
         }
 
         public IEnumerable<string> GetOpenApiSearchPaths()

--- a/src/Microsoft.HttpRepl/Preferences/OpenApiSearchPathsProvider.cs
+++ b/src/Microsoft.HttpRepl/Preferences/OpenApiSearchPathsProvider.cs
@@ -1,0 +1,65 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.HttpRepl.OpenApi;
+
+namespace Microsoft.HttpRepl.Preferences
+{
+    internal class OpenApiSearchPathsProvider : IOpenApiSearchPathsProvider
+    {
+        // OpenAPI description search paths are appended to the base url to
+        // attempt to find the description document. A search path is a
+        // relative url that is appended to the base url using Uri.TryCreate,
+        // so the semantics of relative urls matter here.
+        // Example: Base path https://localhost/v1/ and search path openapi.json
+        //          will result in https://localhost/v1/openapi.json being tested.
+        // Example: Base path https://localhost/v1/ and search path /openapi.json
+        //          will result in https://localhost/openapi.json being tested.
+        internal static IEnumerable<string> DefaultSearchPaths { get; } = new[] {
+            "swagger.json",
+            "/swagger.json",
+            "swagger/v1/swagger.json",
+            "/swagger/v1/swagger.json",
+            "openapi.json",
+            "/openapi.json",
+        };
+
+        private readonly IPreferences _preferences;
+        public OpenApiSearchPathsProvider(IPreferences preferences)
+        {
+            _preferences = preferences;
+        }
+
+        public IEnumerable<string> GetOpenApiSearchPaths()
+        {
+            string[] configSearchPaths = Split(_preferences.GetValue(WellKnownPreference.SwaggerSearchPaths));
+
+            if (configSearchPaths.Length > 0)
+            {
+                return configSearchPaths;
+            }
+
+            string[] addToSearchPaths = Split(_preferences.GetValue(WellKnownPreference.SwaggerAddToSearchPaths));
+            string[] removeFromSearchPaths = Split(_preferences.GetValue(WellKnownPreference.SwaggerRemoveFromSearchPaths));
+
+            return DefaultSearchPaths.Union(addToSearchPaths).Except(removeFromSearchPaths);
+        }
+
+        private static string[] Split(string searchPaths)
+        {
+            if (string.IsNullOrWhiteSpace(searchPaths))
+            {
+                return Array.Empty<string>();
+            }
+            else
+            {
+                return searchPaths.Split('|', StringSplitOptions.RemoveEmptyEntries);
+            }
+        }
+    }
+}

--- a/src/Microsoft.HttpRepl/Preferences/WellKnownPreference.cs
+++ b/src/Microsoft.HttpRepl/Preferences/WellKnownPreference.cs
@@ -174,6 +174,10 @@ namespace Microsoft.HttpRepl.Preferences
 
         public static string SwaggerUIEndpoint { get; } = "swagger.uiEndpoint";
 
+        public static string SwaggerRemoveFromSearchPaths => "swagger.removeFromSearchPaths";
+
+        public static string SwaggerAddToSearchPaths => "swagger.addToSearchPaths";
+
         public static string UseDefaultCredentials { get; } = "httpClient.useDefaultCredentials";
 
         public static string HttpClientUserAgent { get; } = "httpClient.userAgent";

--- a/test/Microsoft.HttpRepl.Fakes/FakePreferences.cs
+++ b/test/Microsoft.HttpRepl.Fakes/FakePreferences.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.HttpRepl.Preferences;
+using Microsoft.Repl.ConsoleHandling;
+
+namespace Microsoft.HttpRepl.Fakes
+{
+    public class FakePreferences : IPreferences
+    {
+        private readonly Dictionary<string, string> _currentPreferences;
+
+        public FakePreferences()
+        {
+            DefaultPreferences = new Dictionary<string, string>();
+            _currentPreferences = new();
+        }
+
+        public IReadOnlyDictionary<string, string> DefaultPreferences { get; }
+        public IReadOnlyDictionary<string, string> CurrentPreferences => _currentPreferences;
+
+        public bool GetBoolValue(string preference, bool defaultValue = false)
+        {
+            if (CurrentPreferences.TryGetValue(preference, out string value) && bool.TryParse(value, out bool result))
+            {
+                return result;
+            }
+
+            return defaultValue;
+        }
+
+        public AllowedColors GetColorValue(string preference, AllowedColors defaultValue = AllowedColors.None)
+        {
+            if (CurrentPreferences.TryGetValue(preference, out string value) && Enum.TryParse(value, true, out AllowedColors result))
+            {
+                return result;
+            }
+
+            return defaultValue;
+        }
+
+        public int GetIntValue(string preference, int defaultValue = 0)
+        {
+            if (CurrentPreferences.TryGetValue(preference, out string value) && int.TryParse(value, out int result))
+            {
+                return result;
+            }
+
+            return defaultValue;
+        }
+
+        public string GetValue(string preference, string defaultValue = null)
+        {
+            if (CurrentPreferences.TryGetValue(preference, out string value))
+            {
+                return value;
+            }
+
+            return defaultValue;
+        }
+
+        public bool SetValue(string preference, string value)
+        {
+            _currentPreferences[preference] = value;
+            return true;
+        }
+
+        public bool TryGetValue(string preference, out string value) => CurrentPreferences.TryGetValue(preference, out value);
+    }
+}

--- a/test/Microsoft.HttpRepl.Fakes/FakePreferences.cs
+++ b/test/Microsoft.HttpRepl.Fakes/FakePreferences.cs
@@ -8,7 +8,7 @@ using Microsoft.Repl.ConsoleHandling;
 
 namespace Microsoft.HttpRepl.Fakes
 {
-    public class FakePreferences : IPreferences
+    public sealed class FakePreferences : IPreferences
     {
         private readonly Dictionary<string, string> _currentPreferences;
 

--- a/test/Microsoft.HttpRepl.Tests/Preferences/OpenApiSearchPathsProviderTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/Preferences/OpenApiSearchPathsProviderTests.cs
@@ -1,0 +1,124 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.HttpRepl.Fakes;
+using Microsoft.HttpRepl.Preferences;
+using Xunit;
+
+namespace Microsoft.HttpRepl.Tests.Preferences
+{
+    public class OpenApiSearchPathsProviderTests
+    {
+        [Fact]
+        public void WithNoOverrides_ReturnsDefault()
+        {
+            // Arrange
+            NullPreferences preferences = new();
+            OpenApiSearchPathsProvider provider = new(preferences);
+            IEnumerable<string> expectedPaths = OpenApiSearchPathsProvider.DefaultSearchPaths;
+
+            // Act
+            IEnumerable<string> paths = provider.GetOpenApiSearchPaths();
+
+            // Assert
+            AssertPathLists(expectedPaths, paths);
+        }
+
+        [Fact]
+        public void WithFullOverride_ReturnsConfiguredOverride()
+        {
+            // Arrange
+            string searchPathOverrides = "/red|/green|/blue";
+            FakePreferences preferences = new();
+            preferences.SetValue(WellKnownPreference.SwaggerSearchPaths, searchPathOverrides);
+            OpenApiSearchPathsProvider provider = new(preferences);
+            string[] expectedPaths = searchPathOverrides.Split('|');
+
+            // Act
+            IEnumerable<string> paths = provider.GetOpenApiSearchPaths();
+
+            // Assert
+            AssertPathLists(expectedPaths, paths);
+        }
+
+        [Fact]
+        public void WithAdditions_ReturnsDefaultPlusAdditions()
+        {
+            // Arrange
+            string[] searchPathAdditions = new[] { "/red", "/green", "/blue" };
+            FakePreferences preferences = new();
+            preferences.SetValue(WellKnownPreference.SwaggerAddToSearchPaths, string.Join('|', searchPathAdditions));
+            OpenApiSearchPathsProvider provider = new(preferences);
+            IEnumerable<string> expectedPaths = OpenApiSearchPathsProvider.DefaultSearchPaths.Union(searchPathAdditions);
+
+            // Act
+            IEnumerable<string> paths = provider.GetOpenApiSearchPaths();
+
+            // Assert
+            AssertPathLists(expectedPaths, paths);
+        }
+
+        [Fact]
+        public void WithRemovals_ReturnsDefaultMinusRemovals()
+        {
+            // Arrange
+            string[] searchPathRemovals = new[] { "swagger.json", "/swagger.json", "swagger/v1/swagger.json", "/swagger/v1/swagger.json" };
+            FakePreferences preferences = new();
+            preferences.SetValue(WellKnownPreference.SwaggerRemoveFromSearchPaths, string.Join('|', searchPathRemovals));
+            OpenApiSearchPathsProvider provider = new(preferences);
+            IEnumerable<string> expectedPaths = OpenApiSearchPathsProvider.DefaultSearchPaths.Except(searchPathRemovals);
+
+            // Act
+            IEnumerable<string> paths = provider.GetOpenApiSearchPaths();
+
+            // Assert
+            AssertPathLists(expectedPaths, paths);
+        }
+
+        [Fact]
+        public void WithAdditionsAndRemovals_ReturnsCorrectSet()
+        {
+            // Arrange
+            string[] searchPathAdditions = new[] { "/red", "/green", "/blue" };
+            string[] searchPathRemovals = new[] { "swagger.json", "/swagger.json", "swagger/v1/swagger.json", "/swagger/v1/swagger.json" };
+            FakePreferences preferences = new();
+            preferences.SetValue(WellKnownPreference.SwaggerAddToSearchPaths, string.Join('|', searchPathAdditions));
+            preferences.SetValue(WellKnownPreference.SwaggerRemoveFromSearchPaths, string.Join('|', searchPathRemovals));
+            OpenApiSearchPathsProvider provider = new(preferences);
+            IEnumerable<string> expectedPaths = OpenApiSearchPathsProvider.DefaultSearchPaths.Union(searchPathAdditions).Except(searchPathRemovals);
+
+            // Act
+            IEnumerable<string> paths = provider.GetOpenApiSearchPaths();
+
+            // Assert
+            AssertPathLists(expectedPaths, paths);
+        }
+
+        private static void AssertPathLists(IEnumerable<string> expectedPaths, IEnumerable<string> paths)
+        {
+            Assert.NotNull(expectedPaths);
+            Assert.NotNull(paths);
+
+            IEnumerator<string> expectedPathsEnumerator = expectedPaths.GetEnumerator();
+            IEnumerator<string> pathsEnumerator = paths.GetEnumerator();
+
+            while (expectedPathsEnumerator.MoveNext())
+            {
+                Assert.True(pathsEnumerator.MoveNext(), $"Missing path \"{expectedPathsEnumerator.Current}\"");
+                Assert.Equal(expectedPathsEnumerator.Current, pathsEnumerator.Current, StringComparer.Ordinal);
+            }
+
+            if (pathsEnumerator.MoveNext())
+            {
+                // We can't do a one-liner here like the Missing path version above because
+                // the order the second parameter is evaluated regardless of the result of the
+                // evaluation of the first parameter. Also xUnit doesn't have an Assert.Fail,
+                // so we have to use Assert.True(false) per their comparison chart.
+                Assert.True(false, $"Extra path \"{pathsEnumerator.Current}\"");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #360. 

Adds two additional preferences:

- `swagger.addToSearchPaths` (adds the specified paths to the default list)
- `swagger.removeFromSearchPaths` (removes the specified paths from the default list if they exist)

and configures the original available preference (`swagger.searchPaths`) to override both the default list _and_ the two new preferences.
