### PR TITLE
Remove --response option from HTTP commands

### DIFF
--- a/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
@@ -672,7 +672,9 @@ namespace Microsoft.HttpRepl.Commands
 
         protected override IEnumerable<string> GetOptionValueCompletions(IShellState shellState, HttpState programState, string optionId, DefaultCommandInput<ICoreParseResult> commandInput, ICoreParseResult parseResult, string normalizedCompletionText)
         {
-            if (string.Equals(optionId, BodyFileOption, StringComparison.Ordinal) || string.Equals(optionId, ResponseBodyFileOption, StringComparison.OrdinalIgnoreCase) || string.Equals(optionId, ResponseHeadersFileOption, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(optionId, BodyFileOption, StringComparison.Ordinal) ||
+                string.Equals(optionId, ResponseBodyFileOption, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(optionId, ResponseHeadersFileOption, StringComparison.OrdinalIgnoreCase))
             {
                 return FileSystemCompletion.GetCompletions(normalizedCompletionText);
             }

--- a/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
@@ -397,23 +397,14 @@ namespace Microsoft.HttpRepl.Commands
                 await FormatBodyAsync(commandInput, programState, consoleManager, response.Content, bodyFileOutput, _preferences, cancellationToken).ConfigureAwait(false);
             }
 
-            if (headersTargetFile != null && !string.Equals(headersTargetFile, bodyTargetFile, StringComparison.Ordinal))
+            if (headersTargetFile != null && headerFileOutput != null)
             {
-                headerFileOutput.Add("");
-                IEnumerable<string> allOutput = headerFileOutput.Concat(bodyFileOutput);
-                _fileSystem.WriteAllLinesToFile(headersTargetFile, allOutput);
+                _fileSystem.WriteAllLinesToFile(headersTargetFile, headerFileOutput);
             }
-            else
-            {
-                if (headersTargetFile != null && headerFileOutput != null)
-                {
-                    _fileSystem.WriteAllLinesToFile(headersTargetFile, headerFileOutput);
-                }
 
-                if (bodyTargetFile != null && bodyFileOutput != null)
-                {
-                    _fileSystem.WriteAllLinesToFile(bodyTargetFile, bodyFileOutput);
-                }
+            if (bodyTargetFile != null && bodyFileOutput != null)
+            {
+                _fileSystem.WriteAllLinesToFile(bodyTargetFile, bodyFileOutput);
             }
 
             consoleManager.WriteLine();

--- a/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
@@ -31,7 +31,6 @@ namespace Microsoft.HttpRepl.Commands
         private const string HeaderOption = nameof(HeaderOption);
         private const string ResponseHeadersFileOption = nameof(ResponseHeadersFileOption);
         private const string ResponseBodyFileOption = nameof(ResponseBodyFileOption);
-        private const string ResponseFileOption = nameof(ResponseFileOption);
         private const string BodyFileOption = nameof(BodyFileOption);
         private const string NoBodyOption = nameof(NoBodyOption);
         private const string NoFormattingOption = nameof(NoFormattingOption);
@@ -75,7 +74,6 @@ namespace Microsoft.HttpRepl.Commands
                 CommandInputSpecificationBuilder builder = CommandInputSpecification.Create(Verb)
                     .MaximumArgCount(1)
                     .WithOption(new CommandOptionSpecification(HeaderOption, requiresValue: true, forms: new[] { "--header", "-h" }))
-                    .WithOption(new CommandOptionSpecification(ResponseFileOption, requiresValue: true, maximumOccurrences: 1, forms: new[] { "--response", }))
                     .WithOption(new CommandOptionSpecification(ResponseHeadersFileOption, requiresValue: true, maximumOccurrences: 1, forms: new[] { "--response:headers", }))
                     .WithOption(new CommandOptionSpecification(ResponseBodyFileOption, requiresValue: true, maximumOccurrences: 1, forms: new[] { "--response:body", }))
                     .WithOption(new CommandOptionSpecification(NoFormattingOption, maximumOccurrences: 1, forms: new[] { "--no-formatting", "-F" }))
@@ -158,12 +156,18 @@ namespace Microsoft.HttpRepl.Commands
                     }
                 }
 
-                InputElement responseFileOption = commandInput.Options[ResponseFileOption].Any() ? commandInput.Options[ResponseFileOption][0] : null;
                 InputElement responseHeadersFileOption = commandInput.Options[ResponseHeadersFileOption].Any() ? commandInput.Options[ResponseHeadersFileOption][0] : null;
                 InputElement responseBodyFileOption = commandInput.Options[ResponseBodyFileOption].Any() ? commandInput.Options[ResponseBodyFileOption][0] : null;
 
-                string headersTarget = responseHeadersFileOption?.Text ?? responseFileOption?.Text;
-                string bodyTarget = responseBodyFileOption?.Text ?? responseFileOption?.Text;
+                string headersTarget = responseHeadersFileOption?.Text;
+                string bodyTarget = responseBodyFileOption?.Text;
+
+                if (!string.IsNullOrWhiteSpace(headersTarget) &&
+                    string.Equals(headersTarget, bodyTarget, StringComparison.OrdinalIgnoreCase))
+                {
+                    shellState.ConsoleManager.Error.WriteLine(Strings.BaseHttpCommand_Error_SameBodyAndHeaderFileName.SetColor(programState.ErrorColor));
+                    return;
+                }
 
                 try
                 {
@@ -607,7 +611,7 @@ namespace Microsoft.HttpRepl.Commands
         protected override string GetHelpDetails(IShellState shellState, HttpState programState, DefaultCommandInput<ICoreParseResult> commandInput, ICoreParseResult parseResult)
         {
             StringBuilder helpText = new StringBuilder();
-            helpText.Append(Resources.Strings.Usage.Bold());
+            helpText.Append(Strings.Usage.Bold());
             helpText.AppendLine($"{Verb.ToUpperInvariant()} [Options]");
             helpText.AppendLine();
             helpText.AppendLine($"Issues a {Verb.ToUpperInvariant()} request.");
@@ -677,7 +681,7 @@ namespace Microsoft.HttpRepl.Commands
 
         protected override IEnumerable<string> GetOptionValueCompletions(IShellState shellState, HttpState programState, string optionId, DefaultCommandInput<ICoreParseResult> commandInput, ICoreParseResult parseResult, string normalizedCompletionText)
         {
-            if (string.Equals(optionId, BodyFileOption, StringComparison.Ordinal) || string.Equals(optionId, ResponseFileOption, StringComparison.OrdinalIgnoreCase) || string.Equals(optionId, ResponseBodyFileOption, StringComparison.OrdinalIgnoreCase) || string.Equals(optionId, ResponseHeadersFileOption, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(optionId, BodyFileOption, StringComparison.Ordinal) || string.Equals(optionId, ResponseBodyFileOption, StringComparison.OrdinalIgnoreCase) || string.Equals(optionId, ResponseHeadersFileOption, StringComparison.OrdinalIgnoreCase))
             {
                 return FileSystemCompletion.GetCompletions(normalizedCompletionText);
             }

--- a/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
+++ b/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
@@ -151,6 +151,15 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The output files for the headers and the body must be two different files.
+        /// </summary>
+        internal static string BaseHttpCommand_Error_SameBodyAndHeaderFileName {
+            get {
+                return ResourceManager.GetString("BaseHttpCommand_Error_SameBodyAndHeaderFileName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Streaming the response, press any key to stop....
         /// </summary>
         internal static string BaseHttpCommand_FormatBodyAsync_Streaming {

--- a/src/Microsoft.HttpRepl/Resources/Strings.resx
+++ b/src/Microsoft.HttpRepl/Resources/Strings.resx
@@ -424,4 +424,7 @@ The .NET Core tools collect usage data in order to help us improve your experien
   <data name="ApiConnection_Logging_Successful" xml:space="preserve">
     <value>Successful</value>
   </data>
+  <data name="BaseHttpCommand_Error_SameBodyAndHeaderFileName" xml:space="preserve">
+    <value>The output files for the headers and the body must be two different files</value>
+  </data>
 </root>

--- a/src/Microsoft.Repl/Parsing/CoreParser.cs
+++ b/src/Microsoft.Repl/Parsing/CoreParser.cs
@@ -38,22 +38,26 @@ namespace Microsoft.Repl.Parsing
 
                     //Check for the closing quote
                     int sectionLength = sections[i].Length;
-                    if (sections[i][sectionLength - 1] == '"')
+                    bool justOneCharacter = sectionLength == 1;
+                    bool endsWithDoubleQuote = sections[i][sectionLength - 1] == '"';
+                    bool lastCharacterIsEscaped = !justOneCharacter && sections[i][sectionLength - 2] == '\\';
+                    if (endsWithDoubleQuote && !lastCharacterIsEscaped)
                     {
-                        if (sectionLength > 1 && sections[i][sectionLength - 2] != '\\')
-                        {
-                            isInQuotedSection = false;
-                        }
+                        isInQuotedSection = false;
                     }
                 }
-                //Not in a quoted section, check to see if we're starting one
+                //Not in a quoted section, check to see if we're starting one (and not finishing it at the same time)
                 else
                 {
                     sectionStartLookup[i] = runningIndex;
 
-                    if (sections[i].Length > 0)
+                    if (thisSectionLength > 0)
                     {
-                        if (sections[i][0] == '"')
+                        bool startsWithDoubleQuote = sections[i][0] == '"';
+                        bool justOneCharacter = thisSectionLength == 1;
+                        bool endsWithDoubleQuote = sections[i][thisSectionLength - 1] == '"';
+                        bool lastCharacterIsEscaped = !justOneCharacter && sections[i][thisSectionLength - 2] == '\\';
+                        if (startsWithDoubleQuote && (!endsWithDoubleQuote || lastCharacterIsEscaped))
                         {
                             isInQuotedSection = true;
                         }

--- a/test/Microsoft.HttpRepl.Tests/Commands/GetCommandTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/Commands/GetCommandTests.cs
@@ -223,5 +223,32 @@ namespace Microsoft.HttpRepl.Tests.Commands
             Assert.Equal("Content-Type: text/plain", result[6]);
             Assert.Equal(unformattedResponse, result[7]);
         }
+
+        [Fact]
+        public async Task ExecuteAsync_WithSameHeadersAndBodyPaths_VerifyError()
+        {
+            // Arrange
+            string fileName = "\"/myfile.txt\"";
+
+            ArrangeInputs(commandText: $"GET --response:headers {fileName} --response:body {fileName}",
+                baseAddress: _baseAddress,
+                path: null,
+                urlsWithResponse: null,
+                out MockedShellState shellState,
+                out HttpState httpState,
+                out ICoreParseResult parseResult,
+                out MockedFileSystem fileSystem,
+                out IPreferences preferences);
+
+            string expectedErrorMessage = Strings.BaseHttpCommand_Error_SameBodyAndHeaderFileName.SetColor(httpState.ErrorColor);
+
+            GetCommand getCommand = new GetCommand(fileSystem, preferences);
+
+            // Act
+            await getCommand.ExecuteAsync(shellState, httpState, parseResult, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(expectedErrorMessage, shellState.ErrorMessage);
+        }
     }
 }

--- a/test/Microsoft.Repl.Tests/Parsing/CoreParseResultTests.cs
+++ b/test/Microsoft.Repl.Tests/Parsing/CoreParseResultTests.cs
@@ -95,5 +95,22 @@ namespace Microsoft.Repl.Tests.Parsing
 
             Assert.Equal(expectedSectionCount, parseResult.Sections.Count);
         }
+
+        [Fact]
+        public void Parse_WithQuotesButNoSpaces_DoesNotCombineSections()
+        {
+            // Arrange
+            string commandText = "GET --response:headers \"file.txt\" --response:body \"file.txt\"";
+            int caretPosition = commandText.Length + 1;
+            CoreParser parser = new CoreParser();
+
+            int expectedSectionCount = 5;
+
+            // Act
+            ICoreParseResult parseResult = parser.Parse(commandText, caretPosition);
+
+            // Assert
+            Assert.Equal(expectedSectionCount, parseResult.Sections.Count);
+        }
     }
 }


### PR DESCRIPTION
Resolves #426.

Also fixed a bug in the parser where it didn't handle quoted sections that didn't have spaces in them. The fix is maybe not a complete fix, but I didn't think it was worth going further since we have the `System.CommandLine` work coming up that will hopefully replace the entire parser.