### PR TITLE
OpenAPI validation during connect

### DIFF
--- a/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/BaseHttpCommand.cs
@@ -193,7 +193,7 @@ namespace Microsoft.HttpRepl.Commands
 
             if (swaggerRequeryBehaviorSetting.StartsWith("auto", StringComparison.OrdinalIgnoreCase))
             {
-                ApiConnection apiConnection = new ApiConnection(_preferences, shellState.ConsoleManager, false)
+                ApiConnection apiConnection = new ApiConnection(programState, _preferences, shellState.ConsoleManager, false)
                 {
                     BaseUri = programState.BaseAddress,
                     SwaggerUri = programState.SwaggerEndpoint,

--- a/src/Microsoft.HttpRepl/Commands/ConnectCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ConnectCommand.cs
@@ -91,7 +91,7 @@ namespace Microsoft.HttpRepl.Commands
             string swaggerAddress = GetSwaggerAddressFromCommand(commandInput);
             bool isVerbosityEnabled = GetOptionExistsFromCommand(commandInput, VerbosityOption);
 
-            ApiConnection connectionInfo = GetConnectionInfo(shellState, rootAddress, baseAddress, swaggerAddress, _preferences, isVerbosityEnabled);
+            ApiConnection connectionInfo = GetConnectionInfo(shellState, programState, rootAddress, baseAddress, swaggerAddress, _preferences, isVerbosityEnabled);
 
             bool rootSpecified = !string.IsNullOrWhiteSpace(rootAddress);
             bool baseSpecified = !string.IsNullOrWhiteSpace(baseAddress);
@@ -137,7 +137,7 @@ namespace Microsoft.HttpRepl.Commands
             shellState.ConsoleManager.WriteLine(Resources.Strings.HelpCommand_Core_Details_Line2.Bold().Cyan());
         }
 
-        private ApiConnection GetConnectionInfo(IShellState shellState, string rootAddress, string baseAddress, string swaggerAddress, IPreferences preferences, bool isVerbosityEnabled)
+        private ApiConnection GetConnectionInfo(IShellState shellState, HttpState programState, string rootAddress, string baseAddress, string swaggerAddress, IPreferences preferences, bool isVerbosityEnabled)
         {
             rootAddress = rootAddress?.Trim();
             baseAddress = baseAddress?.Trim();
@@ -159,7 +159,7 @@ namespace Microsoft.HttpRepl.Commands
             // if they specified one directly.
             bool logVerboseMessages = isVerbosityEnabled || !string.IsNullOrWhiteSpace(swaggerAddress);
 
-            ApiConnection apiConnection = new ApiConnection(preferences, shellState.ConsoleManager, logVerboseMessages);
+            ApiConnection apiConnection = new ApiConnection(programState, preferences, shellState.ConsoleManager, logVerboseMessages);
             if (!string.IsNullOrWhiteSpace(rootAddress))
             {
                 // The `dotnet new webapi` template now has a default start url of `swagger`. Because

--- a/src/Microsoft.HttpRepl/Commands/ListCommand.cs
+++ b/src/Microsoft.HttpRepl/Commands/ListCommand.cs
@@ -44,7 +44,7 @@ namespace Microsoft.HttpRepl.Commands
 
                 if (swaggerRequeryBehaviorSetting.StartsWith("auto", StringComparison.OrdinalIgnoreCase))
                 {
-                    ApiConnection apiConnection = new ApiConnection(_preferences, shellState.ConsoleManager, logVerboseMessages: false)
+                    ApiConnection apiConnection = new ApiConnection(programState, _preferences, shellState.ConsoleManager, logVerboseMessages: false)
                     {
                         BaseUri = programState.BaseAddress,
                         SwaggerUri = programState.SwaggerEndpoint,

--- a/src/Microsoft.HttpRepl/OpenApi/ApiDefinitionParseResult.cs
+++ b/src/Microsoft.HttpRepl/OpenApi/ApiDefinitionParseResult.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.HttpRepl.OpenApi
+{
+    public class ApiDefinitionParseResult
+    {
+        public static ApiDefinitionParseResult Failed { get; } = new ApiDefinitionParseResult(false, null, null);
+
+        public bool Success { get; private set; }
+        public IReadOnlyCollection<string> ValidationMessages { get; private set; }
+        public ApiDefinition? ApiDefinition { get; private set; }
+
+        public ApiDefinitionParseResult(bool success, ApiDefinition? apiDefinition, IEnumerable<string>? validationMessages)
+        {
+            Success = success;
+            ApiDefinition = apiDefinition;
+            ValidationMessages = validationMessages is null ? Array.Empty<string>() : new List<string>(validationMessages);
+        }
+    }
+}

--- a/src/Microsoft.HttpRepl/OpenApi/ApiDefinitionReader.cs
+++ b/src/Microsoft.HttpRepl/OpenApi/ApiDefinitionReader.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 
@@ -18,36 +20,38 @@ namespace Microsoft.HttpRepl.OpenApi
             _readers.Add(reader);
         }
 
-        public bool CanHandle(string document)
+        public ApiDefinitionParseResult CanHandle(string document)
         {
             if (document is null)
             {
-                return false;
+                return ApiDefinitionParseResult.Failed;
             }
 
             foreach (IApiDefinitionReader reader in _readers)
             {
-                if (reader.CanHandle(document))
+                ApiDefinitionParseResult result = reader.CanHandle(document);
+                if (result.Success)
                 {
-                    return true;
+                    return result;
                 }
             }
-            return false;
+            return ApiDefinitionParseResult.Failed;
         }
 
-        public ApiDefinition Read(string document, Uri swaggerUri)
+        public ApiDefinitionParseResult Read(string document, Uri? swaggerUri)
         {
             foreach (IApiDefinitionReader reader in _readers)
             {
-                if (reader.CanHandle(document))
+                ApiDefinitionParseResult parseResult = reader.CanHandle(document);
+                if (parseResult.Success)
                 {
-                    ApiDefinition result = reader.ReadDefinition(document, swaggerUri);
+                    ApiDefinitionParseResult result = reader.ReadDefinition(document, swaggerUri);
 
                     return result;
                 }
             }
 
-            return null;
+            return ApiDefinitionParseResult.Failed;
         }
 
         public static void FillDirectoryInfo(DirectoryStructure parent, EndpointMetadata entry)

--- a/src/Microsoft.HttpRepl/OpenApi/IApiDefinitionReader.cs
+++ b/src/Microsoft.HttpRepl/OpenApi/IApiDefinitionReader.cs
@@ -1,14 +1,16 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.HttpRepl.OpenApi
 {
     public interface IApiDefinitionReader
     {
-        bool CanHandle(string document);
+        ApiDefinitionParseResult CanHandle(string document);
 
-        ApiDefinition ReadDefinition(string document, Uri sourceUri);
+        ApiDefinitionParseResult ReadDefinition(string document, Uri? sourceUri);
     }
 }

--- a/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
+++ b/src/Microsoft.HttpRepl/Resources/Strings.Designer.cs
@@ -115,6 +115,15 @@ namespace Microsoft.HttpRepl.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Successful (with warnings).
+        /// </summary>
+        internal static string ApiConnection_Logging_SuccessfulWithWarnings {
+            get {
+                return ResourceManager.GetString("ApiConnection_Logging_SuccessfulWithWarnings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The specified content file, &quot;{0}&quot;, does not exist..
         /// </summary>
         internal static string BaseHttpCommand_Error_ContentFileDoesNotExist {

--- a/src/Microsoft.HttpRepl/Resources/Strings.resx
+++ b/src/Microsoft.HttpRepl/Resources/Strings.resx
@@ -427,4 +427,7 @@ The .NET Core tools collect usage data in order to help us improve your experien
   <data name="BaseHttpCommand_Error_SameBodyAndHeaderFileName" xml:space="preserve">
     <value>The output files for the headers and the body must be two different files</value>
   </data>
+  <data name="ApiConnection_Logging_SuccessfulWithWarnings" xml:space="preserve">
+    <value>Successful (with warnings)</value>
+  </data>
 </root>

--- a/test/Microsoft.HttpRepl.Fakes/ApiDefinitionReaderStub.cs
+++ b/test/Microsoft.HttpRepl.Fakes/ApiDefinitionReaderStub.cs
@@ -18,7 +18,7 @@ namespace Microsoft.HttpRepl.Fakes
             _apiDefinition = apiDefinition;
         }
 
-        public bool CanHandle(string document)
+        public ApiDefinitionParseResult CanHandle(string document)
         {
             JObject doc;
             using (StringReader stringReader = new StringReader(document))
@@ -27,12 +27,12 @@ namespace Microsoft.HttpRepl.Fakes
                 doc = (JObject)serializer.Deserialize(stringReader, typeof(JObject));
             }
 
-            return (doc["fakeApi"]?.ToString() ?? "").StartsWith("1.", StringComparison.Ordinal);
+            return (doc["fakeApi"]?.ToString() ?? "").StartsWith("1.", StringComparison.Ordinal) ? new ApiDefinitionParseResult(true, null, null) : ApiDefinitionParseResult.Failed;
         }
 
-        public ApiDefinition ReadDefinition(string document, Uri sourceUri)
+        public ApiDefinitionParseResult ReadDefinition(string document, Uri sourceUri)
         {
-            return _apiDefinition;
+            return new ApiDefinitionParseResult(true, _apiDefinition, null);
         }
     }
 }

--- a/test/Microsoft.HttpRepl.Tests/OpenApi/ApiDefinitionReaderTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/OpenApi/ApiDefinitionReaderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.HttpRepl.Fakes;
 using Microsoft.HttpRepl.OpenApi;
 using Xunit;
@@ -21,9 +22,9 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             ApiDefinitionReader apiDefinitionReader = new ApiDefinitionReader();
 
-            ApiDefinition definition = apiDefinitionReader.Read(json, null);
+            ApiDefinitionParseResult result = apiDefinitionReader.Read(json, null);
 
-            Assert.Null(definition);
+            Assert.False(result.Success);
         }
 
         [Fact]
@@ -42,9 +43,9 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
             ApiDefinitionReader reader = new ApiDefinitionReader();
             reader.RegisterReader(apiDefinitionReaderStub);
 
-            ApiDefinition result = reader.Read(json, null);
+            ApiDefinitionParseResult result = reader.Read(json, null);
 
-            Assert.Same(apiDefinition, result);
+            Assert.Same(apiDefinition, result.ApiDefinition);
         }
     }
 }

--- a/test/Microsoft.HttpRepl.Tests/OpenApi/OpenApiDotNetApiDefinitionReaderTests.cs
+++ b/test/Microsoft.HttpRepl.Tests/OpenApi/OpenApiDotNetApiDefinitionReaderTests.cs
@@ -15,17 +15,17 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
         [Theory]
         [MemberData(nameof(GetYamlResourcePaths), MemberType = typeof(OpenApiDotNetApiDefinitionReaderTests))]
         [MemberData(nameof(GetJsonResourcePaths), MemberType = typeof(OpenApiDotNetApiDefinitionReaderTests))]
-        public async Task CanHandle_RealOpenApiDescriptions_ReturnsTrue(string resourcePath)
+        public async Task CanHandle_RealOpenApiDescriptions_ReturnsNotNull(string resourcePath)
         {
             // Arrange
             string content = await GetResourceContent(resourcePath);
             OpenApiDotNetApiDefinitionReader apiDefinitionReader = new();
 
             // Act
-            bool actual = apiDefinitionReader.CanHandle(content);
+            ApiDefinitionParseResult actual = apiDefinitionReader.CanHandle(content);
 
             // Assert
-            Assert.True(actual);
+            Assert.True(actual.Success);
         }
 
         [Theory]
@@ -38,10 +38,29 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
             OpenApiDotNetApiDefinitionReader apiDefinitionReader = new();
 
             // Act
-            ApiDefinition actual = apiDefinitionReader.ReadDefinition(content, null);
+            ApiDefinitionParseResult actual = apiDefinitionReader.ReadDefinition(content, null);
 
             // Assert
-            AssertDefinition(expected, actual);
+            AssertDefinition(expected, actual.ApiDefinition);
+        }
+
+        [Fact]
+        public void CanHandle_WithMissingInfoAndPaths_ReturnsValidationMessages()
+        {
+            // Arrange
+            string json = @"
+{
+  ""openapi"": ""3.0.0""
+}
+";
+            OpenApiDotNetApiDefinitionReader apiDefinitionReader = new();
+
+            // Act
+            ApiDefinitionParseResult result = apiDefinitionReader.CanHandle(json);
+
+            // Assert
+            Assert.True(result.Success);
+            Assert.NotEqual(0, result.ValidationMessages.Count);
         }
 
         private void AssertDefinition(ApiDefinition expected, ApiDefinition actual)

--- a/test/Microsoft.HttpRepl.Tests/OpenApi/OpenApiDotNetApiDefinitionReaderV2Tests.cs
+++ b/test/Microsoft.HttpRepl.Tests/OpenApi/OpenApiDotNetApiDefinitionReaderV2Tests.cs
@@ -22,10 +22,10 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader swaggerV2ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = swaggerV2ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = swaggerV2ApiDefinitionReader.ReadDefinition(json, null);
 
-            Assert.NotNull(apiDefinition?.DirectoryStructure);
-            Assert.Empty(apiDefinition.DirectoryStructure.DirectoryNames);
+            Assert.NotNull(result.ApiDefinition?.DirectoryStructure);
+            Assert.Empty(result.ApiDefinition.DirectoryStructure.DirectoryNames);
         }
 
         [Fact]
@@ -42,10 +42,10 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader swaggerV2ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = swaggerV2ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = swaggerV2ApiDefinitionReader.ReadDefinition(json, null);
 
-            Assert.NotNull(apiDefinition?.DirectoryStructure);
-            Assert.Empty(apiDefinition.DirectoryStructure.DirectoryNames);
+            Assert.NotNull(result.ApiDefinition?.DirectoryStructure);
+            Assert.Empty(result.ApiDefinition.DirectoryStructure.DirectoryNames);
         }
 
         [Fact]
@@ -64,9 +64,9 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader swaggerV2ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = swaggerV2ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = swaggerV2ApiDefinitionReader.ReadDefinition(json, null);
 
-            IDirectoryStructure subDirectory = apiDefinition.DirectoryStructure.TraverseTo("/api/Employees");
+            IDirectoryStructure subDirectory = result.ApiDefinition.DirectoryStructure.TraverseTo("/api/Employees");
 
             Assert.Null(subDirectory.RequestInfo);
         }
@@ -87,9 +87,9 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader swaggerV2ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = swaggerV2ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = swaggerV2ApiDefinitionReader.ReadDefinition(json, null);
 
-            Assert.NotNull(apiDefinition?.DirectoryStructure);
+            Assert.NotNull(result.ApiDefinition?.DirectoryStructure);
         }
 
         [Fact]
@@ -145,13 +145,13 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader swaggerV2ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = swaggerV2ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = swaggerV2ApiDefinitionReader.ReadDefinition(json, null);
 
-            Assert.NotNull(apiDefinition?.DirectoryStructure);
-            Assert.Single(apiDefinition.DirectoryStructure.DirectoryNames);
-            Assert.Equal("api", apiDefinition.DirectoryStructure.DirectoryNames.Single());
+            Assert.NotNull(result.ApiDefinition?.DirectoryStructure);
+            Assert.Single(result.ApiDefinition.DirectoryStructure.DirectoryNames);
+            Assert.Equal("api", result.ApiDefinition.DirectoryStructure.DirectoryNames.Single());
 
-            IDirectoryStructure subDirectory = apiDefinition.DirectoryStructure.TraverseTo("/api/Employees");
+            IDirectoryStructure subDirectory = result.ApiDefinition.DirectoryStructure.TraverseTo("/api/Employees");
 
             Assert.Equal(2, subDirectory.RequestInfo.Methods.Count);
             Assert.Contains("Get", subDirectory.RequestInfo.Methods, StringComparer.Ordinal);
@@ -172,9 +172,9 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader swaggerV2ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            bool? result = swaggerV2ApiDefinitionReader.CanHandle(json);
+            ApiDefinitionParseResult result = swaggerV2ApiDefinitionReader.CanHandle(json);
 
-            Assert.False(result);
+            Assert.False(result.Success);
         }
 
         [Fact]
@@ -192,9 +192,9 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader swaggerV2ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            bool? result = swaggerV2ApiDefinitionReader.CanHandle(json);
+            ApiDefinitionParseResult result = swaggerV2ApiDefinitionReader.CanHandle(json);
 
-            Assert.True(result);
+            Assert.True(result.Success);
         }
 
         [Fact]
@@ -211,10 +211,10 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader swaggerV2ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = swaggerV2ApiDefinitionReader.ReadDefinition(json, new Uri("http://localhost/swagger.json"));
+            ApiDefinitionParseResult result = swaggerV2ApiDefinitionReader.ReadDefinition(json, new Uri("http://localhost/swagger.json"));
 
-            Assert.NotNull(apiDefinition?.BaseAddresses);
-            Assert.Empty(apiDefinition.BaseAddresses);
+            Assert.NotNull(result.ApiDefinition?.BaseAddresses);
+            Assert.Empty(result.ApiDefinition.BaseAddresses);
         }
 
         [Fact]
@@ -235,11 +235,11 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader swaggerV2ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = swaggerV2ApiDefinitionReader.ReadDefinition(json, new Uri("http://localhost/swagger.json"));
+            ApiDefinitionParseResult result = swaggerV2ApiDefinitionReader.ReadDefinition(json, new Uri("http://localhost/swagger.json"));
 
-            Assert.NotNull(apiDefinition?.BaseAddresses);
-            Assert.Single(apiDefinition.BaseAddresses);
-            Assert.Equal("https://localhost/", apiDefinition.BaseAddresses[0].Url.ToString(), StringComparer.Ordinal);
+            Assert.NotNull(result.ApiDefinition?.BaseAddresses);
+            Assert.Single(result.ApiDefinition.BaseAddresses);
+            Assert.Equal("https://localhost/", result.ApiDefinition.BaseAddresses[0].Url.ToString(), StringComparer.Ordinal);
         }
 
         [Fact]
@@ -261,12 +261,12 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader swaggerV2ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = swaggerV2ApiDefinitionReader.ReadDefinition(json, new Uri("http://localhost/swagger.json"));
+            ApiDefinitionParseResult result = swaggerV2ApiDefinitionReader.ReadDefinition(json, new Uri("http://localhost/swagger.json"));
 
-            Assert.NotNull(apiDefinition?.BaseAddresses);
-            Assert.Equal(2, apiDefinition.BaseAddresses.Count);
-            Assert.Equal("https://localhost/", apiDefinition.BaseAddresses[0].Url.ToString(), StringComparer.Ordinal);
-            Assert.Equal("http://localhost/", apiDefinition.BaseAddresses[1].Url.ToString(), StringComparer.Ordinal);
+            Assert.NotNull(result.ApiDefinition?.BaseAddresses);
+            Assert.Equal(2, result.ApiDefinition.BaseAddresses.Count);
+            Assert.Equal("https://localhost/", result.ApiDefinition.BaseAddresses[0].Url.ToString(), StringComparer.Ordinal);
+            Assert.Equal("http://localhost/", result.ApiDefinition.BaseAddresses[1].Url.ToString(), StringComparer.Ordinal);
         }
 
         [Fact]
@@ -284,17 +284,17 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader swaggerV2ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = swaggerV2ApiDefinitionReader.ReadDefinition(json, new Uri("https://localhost/swagger.json"));
+            ApiDefinitionParseResult result = swaggerV2ApiDefinitionReader.ReadDefinition(json, new Uri("https://localhost/swagger.json"));
 
-            Assert.NotNull(apiDefinition?.BaseAddresses);
-            Assert.Single(apiDefinition.BaseAddresses);
-            Assert.Equal("https://localhost/", apiDefinition.BaseAddresses[0].Url.ToString(), StringComparer.Ordinal);
+            Assert.NotNull(result.ApiDefinition?.BaseAddresses);
+            Assert.Single(result.ApiDefinition.BaseAddresses);
+            Assert.Equal("https://localhost/", result.ApiDefinition.BaseAddresses[0].Url.ToString(), StringComparer.Ordinal);
 
-            apiDefinition = swaggerV2ApiDefinitionReader.ReadDefinition(json, new Uri("http://localhost/swagger.json"));
+            result = swaggerV2ApiDefinitionReader.ReadDefinition(json, new Uri("http://localhost/swagger.json"));
 
-            Assert.NotNull(apiDefinition?.BaseAddresses);
-            Assert.Single(apiDefinition.BaseAddresses);
-            Assert.Equal("http://localhost/", apiDefinition.BaseAddresses[0].Url.ToString(), StringComparer.Ordinal);
+            Assert.NotNull(result.ApiDefinition?.BaseAddresses);
+            Assert.Single(result.ApiDefinition.BaseAddresses);
+            Assert.Equal("http://localhost/", result.ApiDefinition.BaseAddresses[0].Url.ToString(), StringComparer.Ordinal);
         }
 
         [Fact]
@@ -316,11 +316,11 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader swaggerV2ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = swaggerV2ApiDefinitionReader.ReadDefinition(json, new Uri("http://localhost/swagger.json"));
+            ApiDefinitionParseResult result = swaggerV2ApiDefinitionReader.ReadDefinition(json, new Uri("http://localhost/swagger.json"));
 
-            Assert.NotNull(apiDefinition?.BaseAddresses);
-            Assert.Single(apiDefinition.BaseAddresses);
-            Assert.Equal("https://localhost/api/v2/", apiDefinition.BaseAddresses[0].Url.ToString(), StringComparer.Ordinal);
+            Assert.NotNull(result.ApiDefinition?.BaseAddresses);
+            Assert.Single(result.ApiDefinition.BaseAddresses);
+            Assert.Equal("https://localhost/api/v2/", result.ApiDefinition.BaseAddresses[0].Url.ToString(), StringComparer.Ordinal);
         }
     }
 }

--- a/test/Microsoft.HttpRepl.Tests/OpenApi/OpenApiDotNetApiDefinitionReaderV3Tests.cs
+++ b/test/Microsoft.HttpRepl.Tests/OpenApi/OpenApiDotNetApiDefinitionReaderV3Tests.cs
@@ -22,10 +22,10 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
 
-            Assert.NotNull(apiDefinition?.DirectoryStructure);
-            Assert.Empty(apiDefinition.DirectoryStructure.DirectoryNames);
+            Assert.NotNull(result.ApiDefinition?.DirectoryStructure);
+            Assert.Empty(result.ApiDefinition.DirectoryStructure.DirectoryNames);
         }
 
         [Fact]
@@ -42,10 +42,10 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
 
-            Assert.NotNull(apiDefinition?.DirectoryStructure);
-            Assert.Empty(apiDefinition.DirectoryStructure.DirectoryNames);
+            Assert.NotNull(result.ApiDefinition?.DirectoryStructure);
+            Assert.Empty(result.ApiDefinition.DirectoryStructure.DirectoryNames);
         }
 
         [Fact]
@@ -70,13 +70,13 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
 
-            Assert.NotNull(apiDefinition?.DirectoryStructure);
-            Assert.Single(apiDefinition.DirectoryStructure.DirectoryNames);
-            Assert.Equal("pets", apiDefinition.DirectoryStructure.DirectoryNames.Single());
+            Assert.NotNull(result.ApiDefinition?.DirectoryStructure);
+            Assert.Single(result.ApiDefinition.DirectoryStructure.DirectoryNames);
+            Assert.Equal("pets", result.ApiDefinition.DirectoryStructure.DirectoryNames.Single());
 
-            IDirectoryStructure subDirectory = apiDefinition.DirectoryStructure.TraverseTo("/pets");
+            IDirectoryStructure subDirectory = result.ApiDefinition.DirectoryStructure.TraverseTo("/pets");
 
             Assert.Single(subDirectory.RequestInfo.Methods);
             Assert.Contains("Post", subDirectory.RequestInfo.Methods, StringComparer.Ordinal);
@@ -95,9 +95,9 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
 
-            Assert.NotNull(apiDefinition?.DirectoryStructure);
+            Assert.NotNull(result.ApiDefinition?.DirectoryStructure);
         }
 
         [Fact]
@@ -113,9 +113,9 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
 
-            IDirectoryStructure subDirectory = apiDefinition.DirectoryStructure.TraverseTo("/pets");
+            IDirectoryStructure subDirectory = result.ApiDefinition.DirectoryStructure.TraverseTo("/pets");
 
             Assert.Null(subDirectory.RequestInfo);
         }
@@ -166,13 +166,13 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
 
-            Assert.NotNull(apiDefinition?.DirectoryStructure);
-            Assert.Single(apiDefinition.DirectoryStructure.DirectoryNames);
-            Assert.Equal("pets", apiDefinition.DirectoryStructure.DirectoryNames.Single());
+            Assert.NotNull(result.ApiDefinition?.DirectoryStructure);
+            Assert.Single(result.ApiDefinition.DirectoryStructure.DirectoryNames);
+            Assert.Equal("pets", result.ApiDefinition.DirectoryStructure.DirectoryNames.Single());
 
-            IDirectoryStructure subDirectory = apiDefinition.DirectoryStructure.TraverseTo("/pets");
+            IDirectoryStructure subDirectory = result.ApiDefinition.DirectoryStructure.TraverseTo("/pets");
 
             if (shouldHaveRequest)
             {
@@ -215,13 +215,13 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
 
-            Assert.NotNull(apiDefinition?.DirectoryStructure);
-            Assert.Single(apiDefinition.DirectoryStructure.DirectoryNames);
-            Assert.Equal("pets", apiDefinition.DirectoryStructure.DirectoryNames.Single());
+            Assert.NotNull(result.ApiDefinition?.DirectoryStructure);
+            Assert.Single(result.ApiDefinition.DirectoryStructure.DirectoryNames);
+            Assert.Equal("pets", result.ApiDefinition.DirectoryStructure.DirectoryNames.Single());
 
-            IDirectoryStructure subDirectory = apiDefinition.DirectoryStructure.TraverseTo("/pets");
+            IDirectoryStructure subDirectory = result.ApiDefinition.DirectoryStructure.TraverseTo("/pets");
 
             Assert.Single(subDirectory.RequestInfo.Methods);
             Assert.Contains("Post", subDirectory.RequestInfo.Methods, StringComparer.Ordinal);
@@ -258,13 +258,13 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
 
-            Assert.NotNull(apiDefinition?.DirectoryStructure);
-            Assert.Single(apiDefinition.DirectoryStructure.DirectoryNames);
-            Assert.Equal("pets", apiDefinition.DirectoryStructure.DirectoryNames.Single());
+            Assert.NotNull(result.ApiDefinition?.DirectoryStructure);
+            Assert.Single(result.ApiDefinition.DirectoryStructure.DirectoryNames);
+            Assert.Equal("pets", result.ApiDefinition.DirectoryStructure.DirectoryNames.Single());
 
-            IDirectoryStructure subDirectory = apiDefinition.DirectoryStructure.TraverseTo("/pets");
+            IDirectoryStructure subDirectory = result.ApiDefinition.DirectoryStructure.TraverseTo("/pets");
 
             Assert.Single(subDirectory.RequestInfo.Methods);
             Assert.Contains("Post", subDirectory.RequestInfo.Methods, StringComparer.Ordinal);
@@ -304,13 +304,13 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
 
-            Assert.NotNull(apiDefinition?.DirectoryStructure);
-            Assert.Single(apiDefinition.DirectoryStructure.DirectoryNames);
-            Assert.Equal("pets", apiDefinition.DirectoryStructure.DirectoryNames.Single());
+            Assert.NotNull(result.ApiDefinition?.DirectoryStructure);
+            Assert.Single(result.ApiDefinition.DirectoryStructure.DirectoryNames);
+            Assert.Equal("pets", result.ApiDefinition.DirectoryStructure.DirectoryNames.Single());
 
-            IDirectoryStructure subDirectory = apiDefinition.DirectoryStructure.TraverseTo("/pets");
+            IDirectoryStructure subDirectory = result.ApiDefinition.DirectoryStructure.TraverseTo("/pets");
 
             Assert.Single(subDirectory.RequestInfo.Methods);
             Assert.Contains("Post", subDirectory.RequestInfo.Methods, StringComparer.Ordinal);
@@ -366,13 +366,13 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
 
-            Assert.NotNull(apiDefinition?.DirectoryStructure);
-            Assert.Single(apiDefinition.DirectoryStructure.DirectoryNames);
-            Assert.Equal("pets", apiDefinition.DirectoryStructure.DirectoryNames.Single());
+            Assert.NotNull(result.ApiDefinition?.DirectoryStructure);
+            Assert.Single(result.ApiDefinition.DirectoryStructure.DirectoryNames);
+            Assert.Equal("pets", result.ApiDefinition.DirectoryStructure.DirectoryNames.Single());
 
-            IDirectoryStructure subDirectory = apiDefinition.DirectoryStructure.TraverseTo("/pets");
+            IDirectoryStructure subDirectory = result.ApiDefinition.DirectoryStructure.TraverseTo("/pets");
 
             Assert.Equal(2, subDirectory.RequestInfo.Methods.Count);
             Assert.Contains("Get", subDirectory.RequestInfo.Methods, StringComparer.Ordinal);
@@ -413,13 +413,13 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
 
-            Assert.NotNull(apiDefinition?.DirectoryStructure);
-            Assert.Single(apiDefinition.DirectoryStructure.DirectoryNames);
-            Assert.Equal("pets", apiDefinition.DirectoryStructure.DirectoryNames.Single());
+            Assert.NotNull(result.ApiDefinition?.DirectoryStructure);
+            Assert.Single(result.ApiDefinition.DirectoryStructure.DirectoryNames);
+            Assert.Equal("pets", result.ApiDefinition.DirectoryStructure.DirectoryNames.Single());
 
-            IDirectoryStructure subDirectory = apiDefinition.DirectoryStructure.TraverseTo("/pets");
+            IDirectoryStructure subDirectory = result.ApiDefinition.DirectoryStructure.TraverseTo("/pets");
 
             Assert.Equal(2, subDirectory.RequestInfo.Methods.Count);
             Assert.Contains("Get", subDirectory.RequestInfo.Methods, StringComparer.Ordinal);
@@ -440,9 +440,9 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            bool? result = openApiV3ApiDefinitionReader.CanHandle(json);
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.CanHandle(json);
 
-            Assert.False(result);
+            Assert.False(result.Success);
         }
 
         [Fact]
@@ -460,9 +460,9 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            bool? result = openApiV3ApiDefinitionReader.CanHandle(json);
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.CanHandle(json);
 
-            Assert.True(result);
+            Assert.True(result.Success);
         }
 
         [Fact]
@@ -480,9 +480,9 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            bool? result = openApiV3ApiDefinitionReader.CanHandle(json);
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.CanHandle(json);
 
-            Assert.False(result);
+            Assert.False(result.Success);
         }
 
         [Fact]
@@ -502,10 +502,10 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
 
-            Assert.NotNull(apiDefinition?.BaseAddresses);
-            Assert.Empty(apiDefinition.BaseAddresses);
+            Assert.NotNull(result.ApiDefinition?.BaseAddresses);
+            Assert.Empty(result.ApiDefinition.BaseAddresses);
         }
 
         [Fact]
@@ -531,12 +531,12 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
 
-            Assert.NotNull(apiDefinition?.BaseAddresses);
-            Assert.Single(apiDefinition.BaseAddresses);
-            Assert.Equal("https://localhost/", apiDefinition.BaseAddresses[0].Url.ToString());
-            Assert.Equal("First Server Address", apiDefinition.BaseAddresses[0].Description);
+            Assert.NotNull(result.ApiDefinition?.BaseAddresses);
+            Assert.Single(result.ApiDefinition.BaseAddresses);
+            Assert.Equal("https://localhost/", result.ApiDefinition.BaseAddresses[0].Url.ToString());
+            Assert.Equal("First Server Address", result.ApiDefinition.BaseAddresses[0].Description);
         }
 
         [Fact]
@@ -566,16 +566,16 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.ReadDefinition(json, null);
 
-            Assert.NotNull(apiDefinition?.BaseAddresses);
-            Assert.Equal(2, apiDefinition.BaseAddresses.Count);
+            Assert.NotNull(result.ApiDefinition?.BaseAddresses);
+            Assert.Equal(2, result.ApiDefinition.BaseAddresses.Count);
 
-            Assert.Equal("https://petstore.swagger.io/", apiDefinition.BaseAddresses[0].Url.ToString());
-            Assert.Equal("Production Server Address", apiDefinition.BaseAddresses[0].Description);
+            Assert.Equal("https://petstore.swagger.io/", result.ApiDefinition.BaseAddresses[0].Url.ToString());
+            Assert.Equal("Production Server Address", result.ApiDefinition.BaseAddresses[0].Description);
 
-            Assert.Equal("https://localhost/", apiDefinition.BaseAddresses[1].Url.ToString());
-            Assert.Equal("Local Development Server Address", apiDefinition.BaseAddresses[1].Description);
+            Assert.Equal("https://localhost/", result.ApiDefinition.BaseAddresses[1].Url.ToString());
+            Assert.Equal("Local Development Server Address", result.ApiDefinition.BaseAddresses[1].Description);
         }
 
         [Fact]
@@ -601,12 +601,12 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = openApiV3ApiDefinitionReader.ReadDefinition(json, new Uri("https://localhost/swagger.json"));
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.ReadDefinition(json, new Uri("https://localhost/swagger.json"));
 
-            Assert.NotNull(apiDefinition?.BaseAddresses);
-            Assert.Single(apiDefinition.BaseAddresses);
-            Assert.Equal("https://localhost/api/v2/", apiDefinition.BaseAddresses[0].Url.ToString());
-            Assert.Equal("First Server Address", apiDefinition.BaseAddresses[0].Description);
+            Assert.NotNull(result.ApiDefinition?.BaseAddresses);
+            Assert.Single(result.ApiDefinition.BaseAddresses);
+            Assert.Equal("https://localhost/api/v2/", result.ApiDefinition.BaseAddresses[0].Url.ToString());
+            Assert.Equal("First Server Address", result.ApiDefinition.BaseAddresses[0].Description);
         }
 
         [Fact]
@@ -643,8 +643,8 @@ namespace Microsoft.HttpRepl.Tests.OpenApi
 
             OpenApiDotNetApiDefinitionReader openApiV3ApiDefinitionReader = new OpenApiDotNetApiDefinitionReader();
 
-            ApiDefinition apiDefinition = openApiV3ApiDefinitionReader.ReadDefinition(json, new Uri("https://localhost/swagger.json"));
-            IDirectoryStructure pets = apiDefinition.DirectoryStructure.TraverseTo("pets");
+            ApiDefinitionParseResult result = openApiV3ApiDefinitionReader.ReadDefinition(json, new Uri("https://localhost/swagger.json"));
+            IDirectoryStructure pets = result.ApiDefinition.DirectoryStructure.TraverseTo("pets");
             string requestBody = pets.RequestInfo.GetRequestBodyForContentType(ref contentType, "post");
 
             Assert.NotNull(requestBody);


### PR DESCRIPTION
Resolves #406 

https://github.com/microsoft/OpenAPI.NET provides us with validation messages when it parses an OpenAPI Description. This PR includes those messages in the `--verbose` output of the `connect` command.

Along the way, it also refactors the IApiDefinitionReader definition to handle more information (the above validation messages) and adds some formatting/color to the verbose output.