### PR TITLE
Update SDK to 5.0 RTM and update other references

### DIFF
--- a/build/PackageVersions.targets
+++ b/build/PackageVersions.targets
@@ -8,7 +8,7 @@
     <PackageReference Update="Microsoft.ApplicationInsights.WorkerService" Version="2.15.0" />
     <PackageReference Update="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" PrivateAssets="All" />
-    <PackageReference Update="Microsoft.DotNet.PlatformAbstractions" Version="5.0.0-preview.5.20278.1" />
+    <PackageReference Update="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageReference Update="Microsoft.OpenApi.Readers" Version="1.2.3" />
     <PackageReference Update="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Update="Moq" Version="4.14.7" PrivateAssets="All" />

--- a/build/PackageVersions.targets
+++ b/build/PackageVersions.targets
@@ -16,7 +16,7 @@
     <PackageReference Update="Swashbuckle.AspNetCore" Version="5.6.3" PrivateAssets="All" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
     <PackageReference Update="System.Diagnostics.Process" Version="4.3.0" />
-    <Packagereference Update="System.Text.Encoding.CodePages" Version="5.0.0" />
+    <PackageReference Update="System.Text.Encoding.CodePages" Version="5.0.0" />
     <PackageReference Update="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/build/PackageVersions.targets
+++ b/build/PackageVersions.targets
@@ -5,18 +5,18 @@
     it is a .targets file and imported via Directory.Build.targets.
   -->
   <ItemGroup>
-    <PackageReference Update="Microsoft.ApplicationInsights.WorkerService" Version="2.14.0" />
-    <PackageReference Update="Microsoft.AspNet.WebApi.Client" Version="5.2.6" />
-    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Update="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-    <PackageReference Update="Microsoft.OpenApi.Readers" Version="1.2.2" />
-    <PackageReference Update="Microsoft.Win32.Registry" Version="4.7.0" />
-    <PackageReference Update="Moq" Version="4.12.0" PrivateAssets="All" />
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.2" PrivateAssets="All" />
-    <PackageReference Update="Swashbuckle.AspNetCore" Version="5.0.0-rc2" PrivateAssets="All" />
+    <PackageReference Update="Microsoft.ApplicationInsights.WorkerService" Version="2.15.0" />
+    <PackageReference Update="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
+    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" PrivateAssets="All" />
+    <PackageReference Update="Microsoft.DotNet.PlatformAbstractions" Version="5.0.0-preview.5.20278.1" />
+    <PackageReference Update="Microsoft.OpenApi.Readers" Version="1.2.3" />
+    <PackageReference Update="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Update="Moq" Version="4.14.7" PrivateAssets="All" />
+    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" PrivateAssets="All" />
+    <PackageReference Update="Swashbuckle.AspNetCore" Version="5.6.3" PrivateAssets="All" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
     <PackageReference Update="System.Diagnostics.Process" Version="4.3.0" />
-    <Packagereference Update="System.Text.Encoding.CodePages" Version="4.7.1" />
+    <Packagereference Update="System.Text.Encoding.CodePages" Version="5.0.0" />
     <PackageReference Update="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-rc.2.20479.15"
+    "dotnet": "5.0.100"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.20552.5"


### PR DESCRIPTION
Updates the repo to use the .NET 5 RTM SDK and updates all references to their latest.

Resolves #428 
Resolves #431 