### PR TITLE
Fix console errors

### DIFF
--- a/src/Microsoft.Repl/Commanding/DefaultCommandDispatcher.cs
+++ b/src/Microsoft.Repl/Commanding/DefaultCommandDispatcher.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Repl.Commanding
             shellState = shellState ?? throw new ArgumentNullException(nameof(shellState));
 
             string line = shellState.InputManager.GetCurrentBuffer();
-            TParseResult parseResult = _parser.Parse(line, shellState.ConsoleManager.CaretPosition);
+            TParseResult parseResult = _parser.Parse(line, shellState.InputManager.CaretPosition);
             HashSet<string> suggestions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (ICommand<TProgramState, TParseResult> command in _commands)
@@ -139,7 +139,7 @@ namespace Microsoft.Repl.Commanding
         private async Task ExecuteCommandInternalAsync(IShellState shellState, CancellationToken cancellationToken)
         {
             string line = shellState.InputManager.GetCurrentBuffer();
-            TParseResult parseResult = _parser.Parse(line, shellState.ConsoleManager.CaretPosition);
+            TParseResult parseResult = _parser.Parse(line, shellState.InputManager.CaretPosition);
 
             if (!string.IsNullOrWhiteSpace(parseResult.CommandText))
             {
@@ -171,7 +171,7 @@ namespace Microsoft.Repl.Commanding
             if (!_isReady && !shellState.IsExiting)
             {
                 _onReady(shellState);
-                shellState.ConsoleManager.ResetCommandStart();
+                shellState.InputManager.ResetInput();
                 _isReady = true;
             }
         }

--- a/src/Microsoft.Repl/ConsoleHandling/IConsoleManager.cs
+++ b/src/Microsoft.Repl/ConsoleHandling/IConsoleManager.cs
@@ -10,10 +10,6 @@ namespace Microsoft.Repl.ConsoleHandling
     {
         Point Caret { get; }
 
-        Point CommandStart { get; }
-
-        int CaretPosition { get; }
-
 #pragma warning disable CA1716 // Identifiers should not match keywords
         IWritable Error { get; }
 #pragma warning restore CA1716 // Identifiers should not match keywords
@@ -25,8 +21,6 @@ namespace Microsoft.Repl.ConsoleHandling
         void MoveCaret(int positions);
 
         ConsoleKeyInfo ReadKey(CancellationToken cancellationToken);
-
-        void ResetCommandStart();
 
         IDisposable AddBreakHandler(Action onBreak);
 

--- a/src/Microsoft.Repl/ConsoleHandling/Writable.cs
+++ b/src/Microsoft.Repl/ConsoleHandling/Writable.cs
@@ -1,18 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.Repl.ConsoleHandling
 {
     internal class Writable : IWritable
     {
-        private readonly Func<IDisposable> _caretUpdater;
         private readonly Reporter _reporter;
 
-        public Writable(Func<IDisposable> caretUpdater, Reporter reporter)
+        public Writable(Reporter reporter)
         {
-            _caretUpdater = caretUpdater;
             _reporter = reporter;
         }
 
@@ -24,34 +20,22 @@ namespace Microsoft.Repl.ConsoleHandling
 
         public void Write(char c)
         {
-            using (_caretUpdater())
-            {
-                _reporter.Write(c);
-            }
+            _reporter.Write(c);
         }
 
         public void Write(string s)
         {
-            using (_caretUpdater())
-            {
-                _reporter.Write(s);
-            }
+            _reporter.Write(s);
         }
 
         public void WriteLine()
         {
-            using (_caretUpdater())
-            {
-                _reporter.WriteLine();
-            }
+            _reporter.WriteLine();
         }
 
         public void WriteLine(string s)
         {
-            using (_caretUpdater())
-            {
-                _reporter.WriteLine(s);
-            }
+            _reporter.WriteLine(s);
         }
     }
 }

--- a/src/Microsoft.Repl/IShellState.cs
+++ b/src/Microsoft.Repl/IShellState.cs
@@ -21,5 +21,7 @@ namespace Microsoft.Repl
         ISuggestionManager SuggestionManager { get; }
 
         bool IsExiting { get; set; }
+
+        void MoveCarets(int positions);
     }
 }

--- a/src/Microsoft.Repl/Input/IInputManager.cs
+++ b/src/Microsoft.Repl/Input/IInputManager.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Repl.Input
     {
         bool IsOverwriteMode { get; set; }
 
+        int CaretPosition { get; }
+
         IInputManager RegisterKeyHandler(ConsoleKey key, AsyncKeyPressHandler handler);
 
         IInputManager RegisterKeyHandler(ConsoleKey key, ConsoleModifiers modifiers, AsyncKeyPressHandler handler);
@@ -28,5 +30,7 @@ namespace Microsoft.Repl.Input
         void RemoveCurrentCharacter(IShellState state);
 
         void Clear(IShellState state);
+
+        void MoveCaret(int positions);
     }
 }

--- a/src/Microsoft.Repl/Input/InputManager.cs
+++ b/src/Microsoft.Repl/Input/InputManager.cs
@@ -18,6 +18,24 @@ namespace Microsoft.Repl.Input
 
         public bool IsOverwriteMode { get; set; }
 
+        public int CaretPosition { get; private set; }
+
+        public void MoveCaret(int positions)
+        {
+            if (CaretPosition + positions < 0)
+            {
+                CaretPosition = 0;
+            }
+            else if (CaretPosition + positions > _inputBuffer.Count)
+            {
+                CaretPosition = _inputBuffer.Count;
+            }
+            else
+            {
+                CaretPosition += positions;
+            }
+        }
+
         public void Clear(IShellState state)
         {
             SetInput(state, string.Empty);
@@ -70,18 +88,15 @@ namespace Microsoft.Repl.Input
         {
             state = state ?? throw new ArgumentNullException(nameof(state));
 
-            int caret = state.ConsoleManager.CaretPosition;
-
-            if (caret == _inputBuffer.Count)
+            if (CaretPosition == _inputBuffer.Count)
             {
                 return;
             }
 
             List<char> update = _inputBuffer.ToList();
-            update.RemoveAt(caret);
+            update.RemoveAt(CaretPosition);
             state.ConsoleManager.IsCaretVisible = false;
             SetInput(state, update);
-            state.ConsoleManager.MoveCaret(caret - state.ConsoleManager.CaretPosition);
             state.ConsoleManager.IsCaretVisible = true;
         }
 
@@ -89,17 +104,15 @@ namespace Microsoft.Repl.Input
         {
             state = state ?? throw new ArgumentNullException(nameof(state));
 
-            int caret = state.ConsoleManager.CaretPosition;
-            if (caret == 0)
+            if (CaretPosition == 0)
             {
                 return;
             }
 
             List<char> update = _inputBuffer.ToList();
-            update.RemoveAt(caret - 1);
+            update.RemoveAt(CaretPosition - 1);
             state.ConsoleManager.IsCaretVisible = false;
-            SetInput(state, update, false);
-            state.ConsoleManager.MoveCaret(caret - state.ConsoleManager.CaretPosition - 1);
+            SetInput(state, update);
             state.ConsoleManager.IsCaretVisible = true;
         }
 
@@ -115,6 +128,7 @@ namespace Microsoft.Repl.Input
         public void ResetInput()
         {
             _inputBuffer.Clear();
+            CaretPosition = 0;
         }
 
         private string _ttyState;
@@ -163,7 +177,7 @@ namespace Microsoft.Repl.Input
             }
         }
 
-        private void SetInput(IShellState state, IReadOnlyList<char> input, bool moveCaret = true)
+        private void SetInput(IShellState state, IReadOnlyList<char> input)
         {
             bool oldCaretVisibility = state.ConsoleManager.IsCaretVisible;
             state.ConsoleManager.IsCaretVisible = false;
@@ -173,7 +187,7 @@ namespace Microsoft.Repl.Input
             {
             }
 
-            state.ConsoleManager.MoveCaret(-state.ConsoleManager.CaretPosition + lastCommonPosition);
+            state.ConsoleManager.MoveCaret(-CaretPosition + lastCommonPosition);
             string str = new string(input.Skip(lastCommonPosition).ToArray());
             int trailing = _inputBuffer.Count - input.Count;
 
@@ -184,13 +198,15 @@ namespace Microsoft.Repl.Input
 
             state.ConsoleManager.Write(str);
 
-            if (trailing > 0 && moveCaret)
+            _inputBuffer.Clear();
+            _inputBuffer.AddRange(input);
+
+            if (trailing > 0)
             {
                 state.ConsoleManager.MoveCaret(-trailing);
             }
 
-            _inputBuffer.Clear();
-            _inputBuffer.AddRange(input);
+            CaretPosition = _inputBuffer.Count;
 
             if (oldCaretVisibility)
             {
@@ -234,11 +250,13 @@ namespace Microsoft.Repl.Input
                         //TODO: Verify on a mac whether these are still needed
                         if (keyPress.Key == ConsoleKey.A)
                         {
-                            state.ConsoleManager.MoveCaret(-state.ConsoleManager.CaretPosition);
+                            state.ConsoleManager.MoveCaret(-CaretPosition);
+                            CaretPosition = 0;
                         }
                         else if (keyPress.Key == ConsoleKey.E)
                         {
-                            state.ConsoleManager.MoveCaret(_inputBuffer.Count - state.ConsoleManager.CaretPosition);
+                            state.ConsoleManager.MoveCaret(_inputBuffer.Count - CaretPosition);
+                            CaretPosition = _inputBuffer.Count;
                         }
                     }
                     //TODO: Register these like regular commands
@@ -252,7 +270,7 @@ namespace Microsoft.Repl.Input
                         //Move back a word
                         if (keyPress.Key == ConsoleKey.B)
                         {
-                            int i = state.ConsoleManager.CaretPosition - 1;
+                            int i = CaretPosition - 1;
 
                             if (i < 0)
                             {
@@ -272,13 +290,14 @@ namespace Microsoft.Repl.Input
 
                             if (i > -1)
                             {
-                                state.ConsoleManager.MoveCaret(i - state.ConsoleManager.CaretPosition);
+                                state.ConsoleManager.MoveCaret(i - CaretPosition);
+                                CaretPosition = i;
                             }
                         }
                         //Move forward a word
                         else if (keyPress.Key == ConsoleKey.F)
                         {
-                            int i = state.ConsoleManager.CaretPosition + 1;
+                            int i = CaretPosition + 1;
 
                             if (i >= _inputBuffer.Count)
                             {
@@ -296,7 +315,8 @@ namespace Microsoft.Repl.Input
                                 --i;
                             }
 
-                            state.ConsoleManager.MoveCaret(i - state.ConsoleManager.CaretPosition);
+                            state.ConsoleManager.MoveCaret(i - CaretPosition);
+                            CaretPosition = i;
                         }
                     }
                     else
@@ -319,25 +339,27 @@ namespace Microsoft.Repl.Input
                             continue;
                         }
 
-                        if (state.ConsoleManager.CaretPosition == _inputBuffer.Count)
+                        if (CaretPosition == _inputBuffer.Count)
                         {
                             _inputBuffer.Add(keyPress.KeyChar);
                             state.ConsoleManager.Write(keyPress.KeyChar);
+                            MoveCaret(1);
                         }
                         else if (IsOverwriteMode)
                         {
-                            _inputBuffer[state.ConsoleManager.CaretPosition] = keyPress.KeyChar;
+                            _inputBuffer[CaretPosition] = keyPress.KeyChar;
                             state.ConsoleManager.Write(keyPress.KeyChar);
+                            MoveCaret(1);
                         }
                         else
                         {
                             state.ConsoleManager.IsCaretVisible = false;
-                            _inputBuffer.Insert(state.ConsoleManager.CaretPosition, keyPress.KeyChar);
-                            int currentCaretPosition = state.ConsoleManager.CaretPosition;
-                            string s = new string(_inputBuffer.ToArray(), state.ConsoleManager.CaretPosition, _inputBuffer.Count - state.ConsoleManager.CaretPosition);
+                            _inputBuffer.Insert(CaretPosition, keyPress.KeyChar);
+                            int currentCaretPosition = CaretPosition;
+                            string s = new string(_inputBuffer.ToArray(), CaretPosition, _inputBuffer.Count - CaretPosition);
                             state.ConsoleManager.Write(s);
-                            state.ConsoleManager.MoveCaret(currentCaretPosition - state.ConsoleManager.CaretPosition + 1);
                             state.ConsoleManager.IsCaretVisible = true;
+                            MoveCaret(1);
                         }
                     }
                 }
@@ -352,7 +374,7 @@ namespace Microsoft.Repl.Input
         {
             string str = new string(presses.Select(x => x.KeyChar).ToArray());
 
-            if (state.ConsoleManager.CaretPosition == _inputBuffer.Count)
+            if (CaretPosition == _inputBuffer.Count)
             {
                 _inputBuffer.AddRange(str);
                 state.ConsoleManager.Write(str);
@@ -361,9 +383,9 @@ namespace Microsoft.Repl.Input
             {
                 for (int i = 0; i < str.Length; ++i)
                 {
-                    if (state.ConsoleManager.CaretPosition + i < _inputBuffer.Count)
+                    if (CaretPosition + i < _inputBuffer.Count)
                     {
-                        _inputBuffer[state.ConsoleManager.CaretPosition + i] = str[i];
+                        _inputBuffer[CaretPosition + i] = str[i];
                     }
                     else
                     {
@@ -377,13 +399,14 @@ namespace Microsoft.Repl.Input
             else
             {
                 state.ConsoleManager.IsCaretVisible = false;
-                _inputBuffer.InsertRange(state.ConsoleManager.CaretPosition, str);
-                int currentCaretPosition = state.ConsoleManager.CaretPosition;
-                string s = new string(_inputBuffer.ToArray(), state.ConsoleManager.CaretPosition, _inputBuffer.Count - state.ConsoleManager.CaretPosition);
+                _inputBuffer.InsertRange(CaretPosition, str);
+                int currentCaretPosition = CaretPosition;
+                string s = new string(_inputBuffer.ToArray(), CaretPosition, _inputBuffer.Count - CaretPosition);
                 state.ConsoleManager.Write(s);
-                state.ConsoleManager.MoveCaret(currentCaretPosition - state.ConsoleManager.CaretPosition + str.Length);
+                state.ConsoleManager.MoveCaret(currentCaretPosition - CaretPosition + str.Length);
                 state.ConsoleManager.IsCaretVisible = true;
             }
+            MoveCaret(str.Length);
 
             presses = null;
         }

--- a/src/Microsoft.Repl/Input/KeyHandlers.cs
+++ b/src/Microsoft.Repl/Input/KeyHandlers.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Repl.Input
 
         private static Task End(ConsoleKeyInfo keyInfo, IShellState state, CancellationToken cancellationToken)
         {
-            state.ConsoleManager.MoveCaret(state.InputManager.GetCurrentBuffer().Length - state.ConsoleManager.CaretPosition);
+            state.MoveCarets(state.InputManager.GetCurrentBuffer().Length - state.InputManager.CaretPosition);
             return Task.CompletedTask;
         }
 
@@ -97,7 +97,7 @@ namespace Microsoft.Repl.Input
         {
             state = state ?? throw new ArgumentNullException(nameof(state));
 
-            state.ConsoleManager.MoveCaret(-state.ConsoleManager.CaretPosition);
+            state.MoveCarets(-state.InputManager.CaretPosition);
             return Task.CompletedTask;
         }
 
@@ -105,16 +105,16 @@ namespace Microsoft.Repl.Input
         {
             state = state ?? throw new ArgumentNullException(nameof(state));
 
-            if (state.ConsoleManager.CaretPosition > 0)
+            if (state.InputManager.CaretPosition > 0)
             {
                 if (!keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
                 {
-                    state.ConsoleManager.MoveCaret(-1);
+                    state.MoveCarets(-1);
                 }
                 else
                 {
                     string line = state.InputManager.GetCurrentBuffer();
-                    ICoreParseResult parseResult = state.CommandDispatcher.Parser.Parse(line, state.ConsoleManager.CaretPosition);
+                    ICoreParseResult parseResult = state.CommandDispatcher.Parser.Parse(line, state.InputManager.CaretPosition);
                     int targetSection = parseResult.SelectedSection - (parseResult.CaretPositionWithinSelectedSection > 0 ? 0 : 1);
 
                     if (targetSection < 0)
@@ -123,7 +123,7 @@ namespace Microsoft.Repl.Input
                     }
 
                     int desiredPosition = parseResult.SectionStartLookup[targetSection];
-                    state.ConsoleManager.MoveCaret(desiredPosition - state.ConsoleManager.CaretPosition);
+                    state.MoveCarets(desiredPosition - state.InputManager.CaretPosition);
                 }
             }
 
@@ -136,25 +136,25 @@ namespace Microsoft.Repl.Input
 
             string line = state.InputManager.GetCurrentBuffer();
 
-            if (state.ConsoleManager.CaretPosition < line.Length)
+            if (state.InputManager.CaretPosition < line.Length)
             {
                 if (!keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
                 {
-                    state.ConsoleManager.MoveCaret(1);
+                    state.MoveCarets(1);
                 }
                 else
                 {
-                    ICoreParseResult parseResult = state.CommandDispatcher.Parser.Parse(line, state.ConsoleManager.CaretPosition);
+                    ICoreParseResult parseResult = state.CommandDispatcher.Parser.Parse(line, state.InputManager.CaretPosition);
                     int targetSection = parseResult.SelectedSection + 1;
 
                     if (targetSection >= parseResult.Sections.Count)
                     {
-                        state.ConsoleManager.MoveCaret(line.Length - state.ConsoleManager.CaretPosition);
+                        state.MoveCarets(line.Length - state.InputManager.CaretPosition);
                     }
                     else
                     {
                         int desiredPosition = parseResult.SectionStartLookup[targetSection];
-                        state.ConsoleManager.MoveCaret(desiredPosition - state.ConsoleManager.CaretPosition);
+                        state.MoveCarets(desiredPosition - state.InputManager.CaretPosition);
                     }
                 }
             }

--- a/src/Microsoft.Repl/Scripting/ScriptExecutor.cs
+++ b/src/Microsoft.Repl/Scripting/ScriptExecutor.cs
@@ -45,7 +45,6 @@ namespace Microsoft.Repl.Scripting
                         }
 
                         dispatcher.OnReady(shellState);
-                        shellState.ConsoleManager.ResetCommandStart();
                         shellState.InputManager.SetInput(shellState, commandText);
                         await dispatcher.ExecuteCommandAsync(shellState, cancellationToken).ConfigureAwait(false);
                     }

--- a/src/Microsoft.Repl/ShellState.cs
+++ b/src/Microsoft.Repl/ShellState.cs
@@ -30,5 +30,11 @@ namespace Microsoft.Repl
         public bool IsExiting { get; set; }
 
         public ISuggestionManager SuggestionManager { get; }
+
+        public void MoveCarets(int positions)
+        {
+            ConsoleManager.MoveCaret(positions);
+            InputManager.MoveCaret(positions);
+        }
     }
 }

--- a/src/Microsoft.Repl/Suggestions/SuggestionManager.cs
+++ b/src/Microsoft.Repl/Suggestions/SuggestionManager.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Repl.Suggestions
             shellState = shellState ?? throw new ArgumentNullException(nameof(shellState));
 
             string line = shellState.InputManager.GetCurrentBuffer();
-            ICoreParseResult parseResult = shellState.CommandDispatcher.Parser.Parse(line, shellState.ConsoleManager.CaretPosition);
+            ICoreParseResult parseResult = shellState.CommandDispatcher.Parser.Parse(line, shellState.InputManager.CaretPosition);
             string currentSuggestion;
 
             //Check to see if we're continuing before querying for suggestions again
@@ -61,7 +61,7 @@ namespace Microsoft.Repl.Suggestions
             shellState = shellState ?? throw new ArgumentNullException(nameof(shellState));
 
             string line = shellState.InputManager.GetCurrentBuffer();
-            ICoreParseResult parseResult = shellState.CommandDispatcher.Parser.Parse(line, shellState.ConsoleManager.CaretPosition);
+            ICoreParseResult parseResult = shellState.CommandDispatcher.Parser.Parse(line, shellState.InputManager.CaretPosition);
             string currentSuggestion;
 
             //Check to see if we're continuing before querying for suggestions again

--- a/test/Microsoft.HttpRepl.Fakes/LoggingConsoleManagerDecorator.cs
+++ b/test/Microsoft.HttpRepl.Fakes/LoggingConsoleManagerDecorator.cs
@@ -25,10 +25,6 @@ namespace Microsoft.HttpRepl.Fakes
         #region IConsoleManager
         public Point Caret => _baseConsole.Caret;
 
-        public Point CommandStart => _baseConsole.CommandStart;
-
-        public int CaretPosition => _baseConsole.CaretPosition;
-
         public IWritable Error => _baseConsole.Error;
 
         public bool IsKeyAvailable => _baseConsole.IsKeyAvailable;
@@ -56,11 +52,6 @@ namespace Microsoft.HttpRepl.Fakes
         public ConsoleKeyInfo ReadKey(CancellationToken cancellationToken)
         {
             return _baseConsole.ReadKey(cancellationToken);
-        }
-
-        public void ResetCommandStart()
-        {
-            _baseConsole.ResetCommandStart();
         }
 
         public void Write(char c)

--- a/test/Microsoft.HttpRepl.Fakes/MockInputManager.cs
+++ b/test/Microsoft.HttpRepl.Fakes/MockInputManager.cs
@@ -13,9 +13,16 @@ namespace Microsoft.HttpRepl.Fakes
     {
         private string _inputBuffer;
 
+        public int CaretPosition { get; private set; }
+
         public MockInputManager(string inputBuffer)
         {
             _inputBuffer = inputBuffer;
+        }
+
+        public void MoveCaret(int positions)
+        {
+
         }
 
         public bool IsOverwriteMode { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }

--- a/test/Microsoft.HttpRepl.Fakes/MockedShellState.cs
+++ b/test/Microsoft.HttpRepl.Fakes/MockedShellState.cs
@@ -46,5 +46,11 @@ namespace Microsoft.HttpRepl.Fakes
         public ISuggestionManager SuggestionManager => _shellState.SuggestionManager;
 
         public bool IsExiting { get => _shellState.IsExiting; set => _shellState.IsExiting = value; }
+
+        public void MoveCarets(int positions)
+        {
+            ConsoleManager?.MoveCaret(positions);
+            InputManager?.MoveCaret(positions);
+        }
     }
 }

--- a/test/Microsoft.Repl.Tests/ShellTests.cs
+++ b/test/Microsoft.Repl.Tests/ShellTests.cs
@@ -104,11 +104,11 @@ namespace Microsoft.Repl.Tests
         {
             ConsoleKeyInfo[] keys = new[]
             {
-                GetConsoleKeyInfo('g', ConsoleKey.G),
-                GetConsoleKeyInfo('e', ConsoleKey.E),
-                GetConsoleKeyInfo('t', ConsoleKey.T),
-                GetConsoleKeyInfo('\0', ConsoleKey.LeftArrow),
-                GetConsoleKeyInfo('\0', ConsoleKey.Delete)
+                GetConsoleKeyInfo('g'),
+                GetConsoleKeyInfo('e'),
+                GetConsoleKeyInfo('t'),
+                GetConsoleKeyInfo(ConsoleKey.LeftArrow),
+                GetConsoleKeyInfo(ConsoleKey.Delete)
             };
 
             Shell shell = CreateShell(keys,
@@ -129,11 +129,11 @@ namespace Microsoft.Repl.Tests
         {
             ConsoleKeyInfo[] keys = new[]
             {
-                GetConsoleKeyInfo('g', ConsoleKey.G),
-                GetConsoleKeyInfo('e', ConsoleKey.E),
-                GetConsoleKeyInfo('t', ConsoleKey.T),
-                GetConsoleKeyInfo('\0', ConsoleKey.LeftArrow),
-                GetConsoleKeyInfo('\0', ConsoleKey.Backspace)
+                GetConsoleKeyInfo('g'),
+                GetConsoleKeyInfo('e'),
+                GetConsoleKeyInfo('t'),
+                GetConsoleKeyInfo(ConsoleKey.LeftArrow),
+                GetConsoleKeyInfo(ConsoleKey.Backspace)
             };
 
             Shell shell = CreateShell(keys,
@@ -154,10 +154,10 @@ namespace Microsoft.Repl.Tests
         {
             ConsoleKeyInfo[] keys = new[]
 {
-                GetConsoleKeyInfo('g', ConsoleKey.G),
-                GetConsoleKeyInfo('e', ConsoleKey.E),
-                GetConsoleKeyInfo('t', ConsoleKey.T),
-                GetConsoleKeyInfo('\0', ConsoleKey.Escape),
+                GetConsoleKeyInfo('g'),
+                GetConsoleKeyInfo('e'),
+                GetConsoleKeyInfo('t'),
+                GetConsoleKeyInfo(ConsoleKey.Escape),
             };
             Shell shell = CreateShell(keys,
                 previousCommand: null,
@@ -177,9 +177,9 @@ namespace Microsoft.Repl.Tests
         {
             ConsoleKeyInfo[] keys = new[]
             {
-                GetConsoleKeyInfo('g', ConsoleKey.G),
-                GetConsoleKeyInfo('e', ConsoleKey.E),
-                GetConsoleKeyInfo('t', ConsoleKey.T),
+                GetConsoleKeyInfo('g'),
+                GetConsoleKeyInfo('e'),
+                GetConsoleKeyInfo('t'),
                 new(keyChar: '\0', key: ConsoleKey.U, shift: false, alt: false, control: true),
             };
 
@@ -220,10 +220,10 @@ namespace Microsoft.Repl.Tests
         {
             ConsoleKeyInfo[] keys = new[]
             {
-                GetConsoleKeyInfo('g', ConsoleKey.G),
-                GetConsoleKeyInfo('e', ConsoleKey.E),
-                GetConsoleKeyInfo('t', ConsoleKey.T),
-                GetConsoleKeyInfo('\0', ConsoleKey.F1),
+                GetConsoleKeyInfo('g'),
+                GetConsoleKeyInfo('e'),
+                GetConsoleKeyInfo('t'),
+                GetConsoleKeyInfo(ConsoleKey.F1),
             };
 
             Shell shell = CreateShell(keys,
@@ -244,8 +244,8 @@ namespace Microsoft.Repl.Tests
         {
             ConsoleKeyInfo[] keys = new[]
             {
-                GetConsoleKeyInfo('c', ConsoleKey.C),
-                GetConsoleKeyInfo('\0', ConsoleKey.Tab),
+                GetConsoleKeyInfo('c'),
+                GetConsoleKeyInfo(ConsoleKey.Tab),
             };
 
             Shell shell = CreateShell(keys,
@@ -273,7 +273,7 @@ namespace Microsoft.Repl.Tests
         {
             ConsoleKeyInfo[] keys = new[]
             {
-                GetConsoleKeyInfo('c', ConsoleKey.C),
+                GetConsoleKeyInfo('c'),
                 new(keyChar: '\0', key: ConsoleKey.Tab, shift: true, alt: false, control: false),
             };
 
@@ -302,8 +302,8 @@ namespace Microsoft.Repl.Tests
         {
             ConsoleKeyInfo[] keys = new[]
             {
-                GetConsoleKeyInfo('z', ConsoleKey.Z),
-                GetConsoleKeyInfo('\0', ConsoleKey.Tab),
+                GetConsoleKeyInfo('z'),
+                GetConsoleKeyInfo(ConsoleKey.Tab),
             };
 
             Shell shell = CreateShell(keys,
@@ -324,7 +324,7 @@ namespace Microsoft.Repl.Tests
         {
             ConsoleKeyInfo[] keys = new[]
             {
-                GetConsoleKeyInfo('z', ConsoleKey.Z),
+                GetConsoleKeyInfo('z'),
                 new(keyChar: '\0', key: ConsoleKey.Tab, shift: true, alt: false, control: false)
             };
 
@@ -345,7 +345,7 @@ namespace Microsoft.Repl.Tests
         public async Task RunAsync_WithEnterKeyPress_UpdatesInputBufferWithEmptyString()
         {
             string input = "set base \"https://localhost:44366/\"";
-            List<ConsoleKeyInfo> keys = GetConsoleKeysFromString(input);
+            List<ConsoleKeyInfo> keys = GetConsoleKeyInfo(input);
             keys.Add(new(keyChar: '\0', key: ConsoleKey.Enter, shift: false, alt: false, control: false));
 
             Shell shell = CreateShell(keys,
@@ -363,7 +363,7 @@ namespace Microsoft.Repl.Tests
         public async Task RunAsync_WithLeftArrowKeyPress_VerifyCaretPositionWasUpdated()
         {
             string input = "set base \"https://localhost:44366/\"";
-            List<ConsoleKeyInfo> keys = GetConsoleKeysFromString(input);
+            List<ConsoleKeyInfo> keys = GetConsoleKeyInfo(input);
             keys.Add(new(keyChar: '\0', key: ConsoleKey.LeftArrow, shift: false, alt: false, control: false));
 
             Shell shell = CreateShell(keys,
@@ -382,7 +382,7 @@ namespace Microsoft.Repl.Tests
         public async Task RunAsync_WithControlLeftArrowKeyPress_VerifyCaretPositionWasUpdated()
         {
             string input = "set base \"https://localhost:44366/\"";
-            List<ConsoleKeyInfo> keys = GetConsoleKeysFromString(input);
+            List<ConsoleKeyInfo> keys = GetConsoleKeyInfo(input);
             keys.Add(new(keyChar: '\0', key: ConsoleKey.LeftArrow, shift: false, alt: false, control: true));
 
             Shell shell = CreateShell(keys,
@@ -401,7 +401,7 @@ namespace Microsoft.Repl.Tests
         public async Task RunAsync_WithRightArrowKeyPress_VerifyCaretPositionWasUpdated()
         {
             string input = "set base \"https://localhost:44366/\"";
-            List<ConsoleKeyInfo> keys = GetConsoleKeysFromString(input);
+            List<ConsoleKeyInfo> keys = GetConsoleKeyInfo(input);
             keys.Add(new(keyChar: '\0', key: ConsoleKey.LeftArrow, shift: false, alt: false, control: false));
             keys.Add(new(keyChar: '\0', key: ConsoleKey.LeftArrow, shift: false, alt: false, control: false));
             keys.Add(new(keyChar: '\0', key: ConsoleKey.LeftArrow, shift: false, alt: false, control: false));
@@ -423,7 +423,7 @@ namespace Microsoft.Repl.Tests
         public async Task RunAsync_WithControlRightArrowKeyPress_VerifyCaretPositionWasUpdated()
         {
             string input = "set base \"https://localhost:44366/\"";
-            List<ConsoleKeyInfo> keys = GetConsoleKeysFromString(input);
+            List<ConsoleKeyInfo> keys = GetConsoleKeyInfo(input);
             keys.Add(new(keyChar: '\0', key: ConsoleKey.LeftArrow, shift: false, alt: false, control: false));
             keys.Add(new(keyChar: '\0', key: ConsoleKey.LeftArrow, shift: false, alt: false, control: false));
             keys.Add(new(keyChar: '\0', key: ConsoleKey.LeftArrow, shift: false, alt: false, control: false));
@@ -445,7 +445,7 @@ namespace Microsoft.Repl.Tests
         public async Task RunAsync_WithHomeKeyPress_VerifyCaretPositionWasUpdated()
         {
             string input = "set base \"https://localhost:44366/\"";
-            List<ConsoleKeyInfo> keys = GetConsoleKeysFromString(input);
+            List<ConsoleKeyInfo> keys = GetConsoleKeyInfo(input);
             keys.Add(new(keyChar: '\0', key: ConsoleKey.Home, shift: false, alt: false, control: false));
 
             Shell shell = CreateShell(keys,
@@ -464,7 +464,7 @@ namespace Microsoft.Repl.Tests
         public async Task RunAsync_WithCtrlAKeyPress_VerifyCaretPositionWasUpdated()
         {
             string input = "set base \"https://localhost:44366/\"";
-            List<ConsoleKeyInfo> keys = GetConsoleKeysFromString(input);
+            List<ConsoleKeyInfo> keys = GetConsoleKeyInfo(input);
             keys.Add(new(keyChar: '\0', key: ConsoleKey.A, shift: false, alt: false, control: true));
 
             Shell shell = CreateShell(keys,
@@ -483,7 +483,7 @@ namespace Microsoft.Repl.Tests
         public async Task RunAsync_WithEndKeyPress_VerifyCaretPositionWasUpdated()
         {
             string input = "set base \"https://localhost:44366/\"";
-            List<ConsoleKeyInfo> keys = GetConsoleKeysFromString(input);
+            List<ConsoleKeyInfo> keys = GetConsoleKeyInfo(input);
             keys.Add(new(keyChar: '\0', key: ConsoleKey.LeftArrow, shift: false, alt: false, control: false));
             keys.Add(new(keyChar: '\0', key: ConsoleKey.LeftArrow, shift: false, alt: false, control: false));
             keys.Add(new(keyChar: '\0', key: ConsoleKey.LeftArrow, shift: false, alt: false, control: false));
@@ -505,7 +505,7 @@ namespace Microsoft.Repl.Tests
         public async Task RunAsync_WithCtrlEKeyPress_VerifyCaretPositionWasUpdated()
         {
             string input = "set base \"https://localhost:44366/\"";
-            List<ConsoleKeyInfo> keys = GetConsoleKeysFromString(input);
+            List<ConsoleKeyInfo> keys = GetConsoleKeyInfo(input);
             keys.Add(new(keyChar: '\0', key: ConsoleKey.LeftArrow, shift: false, alt: false, control: false));
             keys.Add(new(keyChar: '\0', key: ConsoleKey.LeftArrow, shift: false, alt: false, control: false));
             keys.Add(new(keyChar: '\0', key: ConsoleKey.LeftArrow, shift: false, alt: false, control: false));
@@ -516,14 +516,47 @@ namespace Microsoft.Repl.Tests
                 nextCommand: null,
                 out CancellationTokenSource cancellationTokenSource);
 
-            IShellState shellState = shell.ShellState;
+            await shell.RunAsync(cancellationTokenSource.Token).ConfigureAwait(false);
+
+            Assert.Equal(input.Length, shell.ShellState.InputManager.CaretPosition);
+        }
+
+        [Fact]
+        public async Task RunAsync_WithInvalidCommand_VerifyInputBufferIsCleared()
+        {
+            string input = "this is an invalid command\n";
+            List<ConsoleKeyInfo> keys = GetConsoleKeyInfo(input);
+
+            Shell shell = CreateShell(keys,
+                previousCommand: null,
+                nextCommand: null,
+                out CancellationTokenSource cancellationTokenSource);
 
             await shell.RunAsync(cancellationTokenSource.Token).ConfigureAwait(false);
 
-            Assert.Equal(input.Length, shellState.InputManager.CaretPosition);
+            Assert.Empty(shell.ShellState.InputManager.GetCurrentBuffer());
+            Assert.Equal(0, shell.ShellState.InputManager.CaretPosition);
         }
 
-        private Shell CreateShell(IEnumerable<ConsoleKeyInfo> consoleKeyInfo,
+        [Fact]
+        public async Task RunAsync_WithTwoInvalidCommandsAndTwoUpArrows_VerifyInputBufferIsCorrect()
+        {
+            string commandOne = "longer invalid command text";
+            string commandTwo = "small invalid cmd";
+            string input = $"{commandOne}\n{commandTwo}\n";
+            List<ConsoleKeyInfo> keys = GetConsoleKeyInfo(input);
+            keys.Add(GetConsoleKeyInfo(ConsoleKey.UpArrow));
+            keys.Add(GetConsoleKeyInfo(ConsoleKey.UpArrow));
+
+            Shell shell = CreateShell(keys, out CancellationTokenSource cancellationTokenSource);
+
+            await shell.RunAsync(cancellationTokenSource.Token).ConfigureAwait(false);
+
+            Assert.Equal(commandOne,shell.ShellState.InputManager.GetCurrentBuffer());
+            Assert.Equal(commandOne.Length, shell.ShellState.InputManager.CaretPosition);
+        }
+
+        private static Shell CreateShell(IEnumerable<ConsoleKeyInfo> consoleKeyInfo,
             string previousCommand,
             string nextCommand,
             out CancellationTokenSource cancellationTokenSource)
@@ -546,44 +579,65 @@ namespace Microsoft.Repl.Tests
             return new Shell(shellState);
         }
 
-        private Shell CreateShell(ConsoleKeyInfo consoleKeyInfo, string previousCommand, string nextCommand, out CancellationTokenSource cancellationTokenSource)
+        private static Shell CreateShell(IEnumerable<ConsoleKeyInfo> consoleKeyInfo, out CancellationTokenSource cancellationTokenSource)
+        {
+            DefaultCommandDispatcher<object> defaultCommandDispatcher = DefaultCommandDispatcher.Create(x => { }, new object());
+
+            cancellationTokenSource = new CancellationTokenSource();
+            MockConsoleManager mockConsoleManager = new MockConsoleManager(consoleKeyInfo, cancellationTokenSource);
+
+            ShellState shellState = new ShellState(defaultCommandDispatcher,
+                consoleManager: mockConsoleManager);
+
+            return new Shell(shellState);
+        }
+
+        private static Shell CreateShell(ConsoleKeyInfo consoleKeyInfo, string previousCommand, string nextCommand, out CancellationTokenSource cancellationTokenSource)
         {
             return CreateShell(new ConsoleKeyInfo[] { consoleKeyInfo }, previousCommand, nextCommand, out cancellationTokenSource);
         }
 
-        private static ConsoleKeyInfo GetConsoleKeyInfo(char keyChar, ConsoleKey key) => new(keyChar, key, shift: false, alt: false, control: false);
-
-        private static List<ConsoleKeyInfo> GetConsoleKeysFromString(string text)
+        /// <summary>
+        /// Converts a string into the series of ConsoleKeyInfo instances that would be used
+        /// to type the string in the console.
+        /// </summary>
+        private static List<ConsoleKeyInfo> GetConsoleKeyInfo(string text)
         {
             List<ConsoleKeyInfo> keys = new();
 
+            text = text.Replace("\r\n", "\n");
+
             foreach (char c in text)
             {
-                switch (c)
-                {
-                    case >= 'a' and <= 'z':
-                        keys.Add(new(keyChar: c, key: (ConsoleKey)(c - 32), shift: false, alt: false, control: false));
-                        break;
-                    case >= 'A' and <= 'Z':
-                        keys.Add(new(keyChar: c, key: (ConsoleKey)c, shift: true, alt: false, control: false));
-                        break;
-                    case >= '0' and <= '9':
-                    case ' ':
-                        keys.Add(new(keyChar: c, key: (ConsoleKey)c, shift: false, alt: false, control: false));
-                        break;
-                    case ':':
-                        keys.Add(new(keyChar: c, key: ConsoleKey.Oem1, shift: true, alt: false, control: false));
-                        break;
-                    case '/':
-                        keys.Add(new(keyChar: c, key: ConsoleKey.Oem2, shift: false, alt: false, control: false));
-                        break;
-                    case '"':
-                        keys.Add(new(keyChar: c, key: ConsoleKey.Oem7, shift: true, alt: false, control: false));
-                        break;
-                }
+                ConsoleKeyInfo consoleKeyInfo = GetConsoleKeyInfo(c);
+                keys.Add(consoleKeyInfo);
             }
 
             return keys;
+        }
+
+        /// <summary>
+        /// Builds a ConsoleKeyInfo object with the specified console key, the null keyChar ('\0') and no modifiers.
+        /// Intended for non-printable keystrokes.
+        /// </summary>
+        private static ConsoleKeyInfo GetConsoleKeyInfo(ConsoleKey key) => new('\0', key, shift: false, alt: false, control: false);
+
+        /// <summary>
+        /// Builds a ConsoleKeyInfo that could produce the specified character
+        /// </summary>
+        private static ConsoleKeyInfo GetConsoleKeyInfo(char keyChar)
+        {
+            return keyChar switch
+            {
+                >= 'a' and <= 'z'        => new(keyChar: keyChar, key: (ConsoleKey)(keyChar - 32), shift: false, alt: false, control: false),
+                >= 'A' and <= 'Z'        => new(keyChar: keyChar, key: (ConsoleKey)keyChar,        shift: true,  alt: false, control: false),
+                >= '0' and <= '9' or ' ' => new(keyChar: keyChar, key: (ConsoleKey)keyChar,        shift: false, alt: false, control: false),
+                ':'                      => new(keyChar: keyChar, key: ConsoleKey.Oem1,            shift: true,  alt: false, control: false),
+                '/'                      => new(keyChar: keyChar, key: ConsoleKey.Oem2,            shift: false, alt: false, control: false),
+                '"'                      => new(keyChar: keyChar, key: ConsoleKey.Oem7,            shift: true,  alt: false, control: false),
+                '\n'                     => new(keyChar: '\r',    key: ConsoleKey.Enter,           shift: false, alt: false, control: false),
+                _                        => throw new InvalidOperationException($"Test setup does not support '{keyChar}' yet."),
+            };
         }
     }
 }


### PR DESCRIPTION
Fixes #443.

See https://github.com/dotnet/HttpRepl/issues/443#issuecomment-728789788 for details on the specific problems in HttpRepl and  https://github.com/microsoft/terminal/issues/8312 for some background on why the issues show up differently (or not at all) in different terminals.

Essentially, HttpRepl tied the caret position on the input buffer to the caret position of the console window in a way that causes problems in virtual terminals (e.g. Windows Terminal). Not all terminals were impacted the same way, though all variants other than vanilla cmd.exe had problems.

To fix this, we "disconnect" the cursor position in the console window from the cursor position in the input buffer, but still move them together when appropriate. The concept of the `CaretPosition` is moved from the ConsoleManager to the InputManager (since it tracks with the input buffer more directly than it does with the console cursor) and the CaretUpdateScope concept is removed completely. 

One thing we are lacking, that this PR does not address, is the ability to actually drive the console output of various consoles to ensure the input buffer caret and the console caret track properly when they're supposed to.