### PR TITLE
Fix improper handling of text insertion

### DIFF
--- a/src/Microsoft.Repl/Input/InputManager.cs
+++ b/src/Microsoft.Repl/Input/InputManager.cs
@@ -355,9 +355,11 @@ namespace Microsoft.Repl.Input
                         {
                             state.ConsoleManager.IsCaretVisible = false;
                             _inputBuffer.Insert(CaretPosition, keyPress.KeyChar);
-                            int currentCaretPosition = CaretPosition;
                             string s = new string(_inputBuffer.ToArray(), CaretPosition, _inputBuffer.Count - CaretPosition);
                             state.ConsoleManager.Write(s);
+                            // Since we're "inserting", move the console cursor back by one fewer
+                            // than the length of the string just written to the console 
+                            state.ConsoleManager.MoveCaret(-1 * (s.Length - 1));
                             state.ConsoleManager.IsCaretVisible = true;
                             MoveCaret(1);
                         }


### PR DESCRIPTION
It looks like this got missed in #457 when addressing #443. 

Essentially, when "inserting" into existing text on the console, we have to write back out the rest of the string (so that it "moves forward" with the insertion). #457's refactoring missed that the console's cursor position needed to be moved back after the Write call. Rather than moving it back completely and then moving it forward again (with the input cursor), we just move it back one less than the length.