### PR TITLE
Drop null character-causing keystrokes

### DIFF
--- a/src/Microsoft.Repl/Input/InputManager.cs
+++ b/src/Microsoft.Repl/Input/InputManager.cs
@@ -337,6 +337,15 @@ namespace Microsoft.Repl.Input
                     }
                     else
                     {
+                        // If we got here, we've processed all handlers we know for
+                        // key combinations. So anything else should have a valid
+                        // character or be the null character. If its the latter,
+                        // we just want to ignore it.
+                        if (keyPress.KeyChar == '\0')
+                        {
+                            continue;
+                        }
+
                         if (state.ConsoleManager.IsKeyAvailable)
                         {
                             if (presses == null)


### PR DESCRIPTION
Resolves #472

This handles a specific case of #119 where the unprintable character coming through is the null character. This seems common enough (perhaps the most common of the scenarios highlighted by #119) to handle on its own. 