### PR TITLE
Use non-deprecated Azure Pipelines Ubuntu pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,7 @@ stages:
 
       - job: Linux
         pool:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-20.04
           container: LinuxContainer
         strategy:
           matrix:


### PR DESCRIPTION
ubuntu-16.04 was removed recently (https://github.com/actions/virtual-environments/issues/3287), bumping to 20.04.