### PR TITLE
Update version to 6.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>
   <PropertyGroup>
-    <VersionPrefix>5.1.0</VersionPrefix>
+    <VersionPrefix>6.0.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Updating the version of the product to 6.0. Partially this is to match the SDK (#530) but also because we're dropping support for 2.1 which ended back in August. Since that's a big breaking change, the version bump is reasonable even if there aren't new features since 5.0.