### PR TITLE
Fix System.Private.Uri CG Alerts

### DIFF
--- a/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
+++ b/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
@@ -21,6 +21,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- This PackageReference is only here to ensure we pick up the newer version
+         without vulnerabilities rather than the default 4.3.0 version -->
+    <PackageReference Include="System.Private.Uri" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="$(RepoSource)\Microsoft.HttpRepl.Telemetry\Microsoft.HttpRepl.Telemetry.csproj" />
     <ProjectReference Include="$(RepoSource)\Microsoft.Repl\Microsoft.Repl.csproj" />
   </ItemGroup>


### PR DESCRIPTION
System.Private.Uri has a number of CVEs for version 4.3.0. We already specified 4.3.2 in the `Directory.Packages.props` file, but since it wasn't directly referenced by any projects it wasn't fixing the issue. This PR adds the reference to the affected project.