### PR TITLE
Remove .NET 5.0 as it is out of support

### DIFF
--- a/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
+++ b/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <AssemblyName>httprepl</AssemblyName>
     <Description>The HTTP Read-Eval-Print Loop (REPL) is a lightweight, cross-platform command-line tool that's supported everywhere .NET Core is supported and is used for making HTTP requests to test ASP.NET Core web APIs and view their results.</Description>
     <PackageId>Microsoft.dotnet-httprepl</PackageId>


### PR DESCRIPTION
.NET 5.0 reached [end of support](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core) last month, so we'll remove it as a target framework.