### PR TITLE
Update AppInsights to latest release version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.15.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
     <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />


### PR DESCRIPTION
To ensure we're still getting telemetry, we need to update to the latest AppInsights SDK. Will need to backport this to the 6.0 branch as well.