### PR TITLE
Update AppInsights to 2.20.0 for release/6.0.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.15.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
     <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />


### PR DESCRIPTION
Updating AppInsights for continued data ingestion on latest release, similar to #563 