### PR TITLE
Update Swashbuckle.AspNetCore to latest

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="Moq" Version="4.14.7" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />


### PR DESCRIPTION
Updating Swashbuckle.AspNetCore to latest to get past a component governance alert