### PR TITLE
Fix CG alert with Newtonsoft

### DIFF
--- a/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
+++ b/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
@@ -21,9 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- This PackageReference is only here to ensure we pick up the newer version
-         without vulnerabilities rather than the default 4.3.0 version -->
+    <!-- These PackageReferences are only here to ensure we pick up the newer
+         versions without vulnerabilities rather than the default versions -->
     <PackageReference Include="System.Private.Uri" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Have a CG alert because Microsoft.HttpRepl is building with an old version of Newtonsoft.Json. Our direct references pull in something newer in other places and we ship the newer one, but this package still builds this way so we need to correct it.