### PR TITLE
Update System.Drawing.Common to avoid vulnerability

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,4 +20,13 @@
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="5.0.0" />
     <PackageVersion Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!--
+      This PackageVersion is only here to deal with a Component Governance alert.
+      Once Microsoft.ApplicationInsights.WorkerService 2.22 is released, we can
+      update our reference to that and remove this.
+    -->
+    <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.HttpRepl.Telemetry/Microsoft.HttpRepl.Telemetry.csproj
+++ b/src/Microsoft.HttpRepl.Telemetry/Microsoft.HttpRepl.Telemetry.csproj
@@ -7,4 +7,13 @@
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" />
     <PackageReference Include="Microsoft.Win32.Registry" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!--
+      This PackageReference is only here to deal with a Component Governance alert.
+      Once Microsoft.ApplicationInsights.WorkerService 2.22 is released, we can
+      update our reference to that and remove this.
+    -->
+    <PackageReference Include="System.Drawing.Common" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
We got a CG alert for `System.Drawing.Common` 4.7.0. Eventually we can update the AppInsights dependency to 2.22 and it'll bring in something without the vulnerability, but for now we need to pin `System.Drawing.Common` to 4.7.2.