### PR TITLE
Update AppInsights to latest version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
     <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />

--- a/src/Microsoft.HttpRepl.Telemetry/Telemetry.cs
+++ b/src/Microsoft.HttpRepl.Telemetry/Telemetry.cs
@@ -99,8 +99,8 @@ namespace Microsoft.HttpRepl.Telemetry
             {
 #pragma warning disable CS0618 // Type or member is obsolete
                 _client = new TelemetryClient();
-#pragma warning restore CS0618 // Type or member is obsolete
                 _client.InstrumentationKey = InstrumentationKey;
+#pragma warning restore CS0618 // Type or member is obsolete
                 _client.Context.Session.Id = CurrentSessionId;
                 _client.Context.Device.OperatingSystem = RuntimeEnvironment.OperatingSystem;
 


### PR DESCRIPTION
2.20 is deprecated, so we need to update.