### PR TITLE
Delete useless null check for CommandTestsBase

### DIFF
--- a/test/Microsoft.HttpRepl.Tests/Commands/CommandTestsBase.cs
+++ b/test/Microsoft.HttpRepl.Tests/Commands/CommandTestsBase.cs
@@ -122,14 +122,11 @@ namespace Microsoft.HttpRepl.Tests.Commands
             {
                 httpState.BaseAddress = new Uri(baseAddress);
 
-                if (path != null)
-                {
-                    string[] pathParts = path.Split('/');
+                string[] pathParts = path.Split('/');
 
-                    foreach (string pathPart in pathParts)
-                    {
-                        httpState.PathSections.Push(pathPart);
-                    }
+                foreach (string pathPart in pathParts)
+                {
+                    httpState.PathSections.Push(pathPart);
                 }
             }
 


### PR DESCRIPTION
Hi! Thank you for this tool! ;)

I read code and found duplicate null check. As you can see, [this](https://github.com/dotnet/HttpRepl/blob/main/test/Microsoft.HttpRepl.Tests/Commands/CommandTestsBase.cs#L125) null check is useless, because [here](https://github.com/dotnet/HttpRepl/blob/main/test/Microsoft.HttpRepl.Tests/Commands/CommandTestsBase.cs#L121) we already check path by null

Hope my changes make your code better ;)