### PR TITLE
Update to .NET8 GA, Update version to 8.0-preview

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>
   <PropertyGroup>
-    <VersionPrefix>7.1.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "8.0.100-rtm.23506.1"
+    "dotnet": "8.0.100"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.23560.1"


### PR DESCRIPTION
With the .NET 8 release today, updating the SDK required to the released 8.0.100 and updating the version number to 8.0.0