### PR TITLE
Add runtime major version rollforward

### DIFF
--- a/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
+++ b/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <RollForward>Major</RollForward>
     <AssemblyName>httprepl</AssemblyName>
     <Description>The HTTP Read-Eval-Print Loop (REPL) is a lightweight, cross-platform command-line tool that's supported everywhere .NET Core is supported and is used for making HTTP requests to test ASP.NET Core web APIs and view their results.</Description>
     <PackageId>Microsoft.dotnet-httprepl</PackageId>


### PR DESCRIPTION
In the past, we've always said that we will make sure to update HttpRepl with each version of .NET (roughly) as it is released. To provide us some flexibility with that, we're enabling the [Major version policy for runtime RollForward](https://learn.microsoft.com/en-us/dotnet/core/versions/selection#framework-dependent-apps-roll-forward). The effect here should be:

1. If the version we compiled for (currently net6.0, net7.0 and net8.0) is available, it will use that specific version.
2. If the version we compiled for is _not_ available, it will look for the lowest major version higher than the specified version and use that.

An example:

In November 2025, a user installs a hypothetical 10.0 version of the .NET Runtime onto a machine that has a hypothetical 9.0 version of the .NET Runtime already installed. No other runtimes are installed. They then install the 8.0 version of HttpRepl (the latest available at the time). When they run HttpRepl, the roll forward policy will not find a 6/7/8 runtime and so will select the 9.0 runtime (the lower of the two available runtimes). If there are no breaking changes in the 9.0 runtime that prevent the tool from running, it will run without error on the 9.0 runtime.

This takes a conservative approach to allowing HttpRepl to run on as-yet-unannounced versions of the .NET runtime while not forcing it onto the newest runtime on a machine (which may eventually have breaking changes that prevent the tool from running).