### PR TITLE
Add CSV exclusion

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,6 +48,10 @@ extends:
         name: $(DncEngInternalBuildPool)
         image: 1es-windows-2022
         os: windows
+      codeSignValidation:
+        # We make copies of our pre-signed binaries to the output directory, but we do not ship those. The signed ones
+        # are in the packages folder and pass CSV without issue. We only ship the signed packages, not any individual binaries
+        additionalTargetsGlobPattern: -|**\bin\**
     customBuildTags:
     - ES365AIMigrationTooling
     stages:


### PR DESCRIPTION
CodeSignValidation is flagging our bin folder artifact, which is just the copy of all of our pre-signed binaries that we create for testing/validation purposes and is not shipped (we only ship the full nuget package, which is signed, as are its contents). This adds an exclusion for that folder so that it doesn't fail the build.