### PR TITLE
Remove net6.0 and net7.0 versions from shipping packages

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>
   <PropertyGroup>
-    <VersionPrefix>8.0.0</VersionPrefix>
+    <VersionPrefix>8.1.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.HttpRepl.Telemetry/Microsoft.HttpRepl.Telemetry.csproj
+++ b/src/Microsoft.HttpRepl.Telemetry/Microsoft.HttpRepl.Telemetry.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" />

--- a/src/Microsoft.HttpRepl.Telemetry/Microsoft.HttpRepl.Telemetry.csproj
+++ b/src/Microsoft.HttpRepl.Telemetry/Microsoft.HttpRepl.Telemetry.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" />

--- a/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
+++ b/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <AssemblyName>httprepl</AssemblyName>
     <Description>The HTTP Read-Eval-Print Loop (REPL) is a lightweight, cross-platform command-line tool that's supported everywhere .NET Core is supported and is used for making HTTP requests to test ASP.NET Core web APIs and view their results.</Description>

--- a/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
+++ b/src/Microsoft.HttpRepl/Microsoft.HttpRepl.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RollForward>Major</RollForward>
     <AssemblyName>httprepl</AssemblyName>
     <Description>The HTTP Read-Eval-Print Loop (REPL) is a lightweight, cross-platform command-line tool that's supported everywhere .NET Core is supported and is used for making HTTP requests to test ASP.NET Core web APIs and view their results.</Description>

--- a/src/Microsoft.Repl/Microsoft.Repl.csproj
+++ b/src/Microsoft.Repl/Microsoft.Repl.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>A framework for creating REPLs in .NET Standard.</Description>
     <PackageTags>dotnet;repl</PackageTags>
     <PackageId>Microsoft.Repl</PackageId>

--- a/src/Microsoft.Repl/Microsoft.Repl.csproj
+++ b/src/Microsoft.Repl/Microsoft.Repl.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>A framework for creating REPLs in .NET Standard.</Description>
     <PackageTags>dotnet;repl</PackageTags>
     <PackageId>Microsoft.Repl</PackageId>


### PR DESCRIPTION
Dropping net6/net7 builds from the nuget package as they're out of support (or will be by the time we ship this in a stable build).

net7.0 is out of support as of May 14, 2024
net6.0 will be going out of support on November 12, 2024

Bumping the version to 8.1 rather than just 8.0.1 since this is a breaking change for anyone trying to run it on those runtimes. 